### PR TITLE
Implement GET /v1/health handler and wire route

### DIFF
--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -1,6 +1,6 @@
 # Turnur AWS CDK (`infra/cdk`)
 
-AWS CDK **v2** (TypeScript) workspace for Turnur infrastructure. This package defines **`TurnurApiStack`**: an API Gateway HTTP API (v2) and a Node 22 stub Lambda ready for route wiring in [#3](https://github.com/StacksOnTheRacks/turnur/issues/3).
+AWS CDK **v2** (TypeScript) workspace for Turnur infrastructure. This package defines **`TurnurApiStack`**: an API Gateway HTTP API (v2) and a Node 22 Lambda wired to **`GET /v1/health`**.
 
 ## Prerequisites
 
@@ -27,17 +27,26 @@ npm run synth
 ```
 
 - **`npm run build`** - compiles TypeScript under `bin/` and `lib/` to `dist/`
-- **`npm test`** - runs Vitest stack assertions (HTTP API + Lambda present; no routes yet)
+- **`npm test`** - runs Vitest handler and stack assertions
 - **`npm run synth`** - emits CloudFormation templates under `cdk.out/` (no AWS credentials required)
+
+## HTTP API
+
+| Method | Path | Auth | Response |
+| --- | --- | --- | --- |
+| `GET` | `/v1/health` | none (public liveness) | HTTP 200, `{ "ok": true }` |
+
+The health route confirms the control-plane Lambda and API Gateway wiring are present. It does not check downstream dependencies (DynamoDB, Cognito, etc.).
 
 ## Layout
 
 | Path | Role |
 | --- | --- |
 | `bin/turnur.ts` | CDK app entry; instantiates `TurnurApiStack` |
-| `lib/turnur-api-stack.ts` | HTTP API (v2) + stub `NodejsFunction` (routes arrive in #3) |
+| `lib/turnur-api-stack.ts` | HTTP API (v2) + health `NodejsFunction` + route wiring |
 | `lib/turnur-api-stack.test.ts` | Vitest template assertions |
-| `lambda/stub-handler.ts` | Placeholder Lambda handler (not the `/v1/health` contract) |
+| `lambda/health-handler.ts` | `GET /v1/health` Lambda handler |
+| `lambda/health-handler.test.ts` | Vitest handler contract tests |
 
 ## Runtime note
 

--- a/infra/cdk/lambda/health-handler.test.ts
+++ b/infra/cdk/lambda/health-handler.test.ts
@@ -1,0 +1,23 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { describe, expect, it } from 'vitest';
+
+import { handler } from './health-handler';
+
+describe('health-handler', () => {
+  it('returns 200 with { ok: true } and JSON content-type', async () => {
+    const event = {
+      routeKey: 'GET /v1/health',
+      requestContext: {
+        http: { method: 'GET' },
+      },
+    } as APIGatewayProxyEventV2;
+
+    const result = await handler(event, {} as never, () => {});
+
+    expect(result).toMatchObject({
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+    expect(JSON.parse(result!.body!)).toEqual({ ok: true });
+  });
+});

--- a/infra/cdk/lambda/health-handler.ts
+++ b/infra/cdk/lambda/health-handler.ts
@@ -1,0 +1,19 @@
+/**
+ * GET /v1/health — unauthenticated liveness check.
+ *
+ * Stable success response (v1): HTTP 200, body `{ "ok": true }` only.
+ * No service name, version, or timestamp in this contract.
+ */
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+
+export type HealthResponseBody = { ok: true };
+
+export const handler: APIGatewayProxyHandlerV2 = async () => {
+  const body: HealthResponseBody = { ok: true };
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+};

--- a/infra/cdk/lambda/stub-handler.ts
+++ b/infra/cdk/lambda/stub-handler.ts
@@ -1,9 +1,0 @@
-import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
-
-export const handler: APIGatewayProxyHandlerV2 = async () => {
-  return {
-    statusCode: 200,
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ message: 'stub' }),
-  };
-};

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -1,11 +1,11 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { TurnurApiStack } from './turnur-api-stack';
 
 describe('TurnurApiStack', () => {
-  it('synthesizes HTTP API and Node 22 Lambda without routes or integrations', () => {
+  it('synthesizes HTTP API, Node 22 Lambda, and GET /v1/health route', () => {
     const app = new cdk.App();
     const stack = new TurnurApiStack(app, 'TurnurApiStackTest');
     const template = Template.fromStack(stack);
@@ -15,7 +15,22 @@ describe('TurnurApiStack', () => {
     template.hasResourceProperties('AWS::Lambda::Function', {
       Runtime: 'nodejs22.x',
     });
-    template.resourceCountIs('AWS::ApiGatewayV2::Route', 0);
-    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 0);
+
+    template.resourceCountIs('AWS::ApiGatewayV2::Route', 1);
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'GET /v1/health',
+      AuthorizationType: 'NONE',
+    });
+
+    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 1);
+    template.hasResourceProperties('AWS::ApiGatewayV2::Integration', {
+      IntegrationType: 'AWS_PROXY',
+      PayloadFormatVersion: '2.0',
+    });
+
+    template.resourceCountIs('AWS::ApiGatewayV2::Authorizer', 0);
+
+    const permissions = template.findResources('AWS::Lambda::Permission');
+    expect(Object.keys(permissions).length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 
 import * as cdk from 'aws-cdk-lib';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Construct } from 'constructs';
@@ -12,7 +13,7 @@ const sharedLambdaBundle = {
 
 export class TurnurApiStack extends cdk.Stack {
   public readonly httpApi: apigwv2.HttpApi;
-  public readonly stubFunction: lambdaNodejs.NodejsFunction;
+  public readonly healthFunction: lambdaNodejs.NodejsFunction;
 
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
@@ -22,11 +23,22 @@ export class TurnurApiStack extends cdk.Stack {
       description: 'Turnur control-plane HTTP API',
     });
 
-    this.stubFunction = new lambdaNodejs.NodejsFunction(this, 'StubFn', {
+    this.healthFunction = new lambdaNodejs.NodejsFunction(this, 'HealthFn', {
       runtime: lambda.Runtime.NODEJS_22_X,
       bundling: sharedLambdaBundle,
-      entry: path.join(__dirname, '../lambda/stub-handler.ts'),
+      entry: path.join(__dirname, '../lambda/health-handler.ts'),
       handler: 'handler',
+    });
+
+    const healthIntegration = new integrations.HttpLambdaIntegration(
+      'HealthInt',
+      this.healthFunction,
+    );
+
+    this.httpApi.addRoutes({
+      path: '/v1/health',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: healthIntegration,
     });
   }
 }


### PR DESCRIPTION
## Summary

- Add `health-handler.ts` returning HTTP 200 with `{ "ok": true }` and export `HealthResponseBody`
- Wire `GET /v1/health` on `TurnurApiStack` via `HttpLambdaIntegration` (no authorizer)
- Replace stub handler; add Vitest coverage for handler and synthesized route/integration/permission
- Document the health contract in `infra/cdk/README.md`

Closes #3

## Test plan

- [x] `cd infra/cdk && npm ci && npm run build && npm test && npm run synth` all exit 0
- [x] Synth template has exactly one `AWS::ApiGatewayV2::Route` (`GET /v1/health`) and one integration
- [x] No authorizers, Cognito, DynamoDB, CloudFront, WebSocket, or EC2 resources in template
- [x] `stub-handler.ts` removed; no remaining references under `infra/cdk/`