### PR TITLE
Add GitHub Actions CI for cdk synth and Vitest on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'infra/cdk/**'
+      - '.github/workflows/ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/cdk/**'
+      - '.github/workflows/ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  infra-cdk:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/cdk
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: infra/cdk/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm run synth


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with a single `infra-cdk` job that runs `npm ci`, `npm run build`, `npm run test`, and `npm run synth` under `infra/cdk/`
- Triggers on `pull_request` and `push` to `main` with path filters for `infra/cdk/**` and `.github/workflows/ci.yml`
- Uses Node 22 with `permissions: contents: read` only; no AWS credentials or deploy steps

Closes #4

## Test plan

- [x] Local parity: `cd infra/cdk && npm ci && npm run build && npm test && npm run synth` passes
- [ ] GitHub Actions CI workflow runs green on this PR
- [ ] Job log shows Node 22 and steps in order under `working-directory: infra/cdk`