### PR TITLE
Add game registry and SDK key storage to TurnurApi stack

### DIFF
--- a/infra/cdk/lib/game-auth/constants.ts
+++ b/infra/cdk/lib/game-auth/constants.ts
@@ -1,0 +1,6 @@
+/** Stable game id for the dev/test fixture row seeded in GameRegistry. */
+export const DEV_FIXTURE_GAME_ID = 'dev-fixture';
+
+/** Precomputed SHA-256 hex of the dev fixture plaintext key (see test-fixtures/). */
+export const DEV_FIXTURE_KEY_HASH =
+  '8f9bd32f48ff076b96de35fcb52bf0b79af1937b289c86aeec4fd4d12cafd2c6';

--- a/infra/cdk/lib/game-auth/hash-sdk-key.test.ts
+++ b/infra/cdk/lib/game-auth/hash-sdk-key.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEV_FIXTURE_KEY_HASH } from './constants';
+import { hashSdkKey } from './hash-sdk-key';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../../test-fixtures/dev-game-key';
+
+describe('hashSdkKey', () => {
+  it('returns SHA-256 lowercase hex of the full key string', () => {
+    expect(hashSdkKey(DEV_FIXTURE_PLAINTEXT_SDK_KEY)).toBe(DEV_FIXTURE_KEY_HASH);
+  });
+});

--- a/infra/cdk/lib/game-auth/hash-sdk-key.ts
+++ b/infra/cdk/lib/game-auth/hash-sdk-key.ts
@@ -1,0 +1,6 @@
+import { createHash } from 'crypto';
+
+/** SHA-256 lowercase-hex digest of the full SDK key string (UTF-8). */
+export function hashSdkKey(sdkKey: string): string {
+  return createHash('sha256').update(sdkKey, 'utf8').digest('hex');
+}

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { describe, expect, it } from 'vitest';
 
+import { DEV_FIXTURE_GAME_ID, DEV_FIXTURE_KEY_HASH } from './game-auth/constants';
 import { TurnurApiStack } from './turnur-api-stack';
 
 describe('TurnurApiStack', () => {
@@ -11,7 +12,6 @@ describe('TurnurApiStack', () => {
     const template = Template.fromStack(stack);
 
     template.resourceCountIs('AWS::ApiGatewayV2::Api', 1);
-    template.resourceCountIs('AWS::Lambda::Function', 1);
     template.hasResourceProperties('AWS::Lambda::Function', {
       Runtime: 'nodejs22.x',
     });
@@ -32,5 +32,27 @@ describe('TurnurApiStack', () => {
 
     const permissions = template.findResources('AWS::Lambda::Permission');
     expect(Object.keys(permissions).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('synthesizes GameRegistry DynamoDB table and dev fixture seed', () => {
+    const app = new cdk.App();
+    const stack = new TurnurApiStack(app, 'TurnurApiStackGameRegistryTest');
+    const template = Template.fromStack(stack);
+
+    template.resourceCountIs('AWS::DynamoDB::Table', 1);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      KeySchema: [{ AttributeName: 'keyHash', KeyType: 'HASH' }],
+      AttributeDefinitions: [{ AttributeName: 'keyHash', AttributeType: 'S' }],
+      BillingMode: 'PAY_PER_REQUEST',
+    });
+
+    template.resourceCountIs('Custom::AWS', 1);
+    const templateJson = JSON.stringify(template.toJSON());
+    expect(templateJson).toContain(DEV_FIXTURE_KEY_HASH);
+    expect(templateJson).toContain(DEV_FIXTURE_GAME_ID);
+    expect(templateJson).toContain('putItem');
+
+    template.hasOutput('GameRegistryTableName', {});
+    template.hasOutput('GameRegistryTableArn', {});
   });
 });

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -3,9 +3,17 @@ import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import {
+  AwsCustomResource,
+  AwsCustomResourcePolicy,
+  PhysicalResourceId,
+} from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
+
+import { DEV_FIXTURE_GAME_ID, DEV_FIXTURE_KEY_HASH } from './game-auth/constants';
 
 const sharedLambdaBundle = {
   externalModules: ['@aws-sdk/*'],
@@ -14,6 +22,7 @@ const sharedLambdaBundle = {
 export class TurnurApiStack extends cdk.Stack {
   public readonly httpApi: apigwv2.HttpApi;
   public readonly healthFunction: lambdaNodejs.NodejsFunction;
+  public readonly gameRegistryTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
@@ -39,6 +48,40 @@ export class TurnurApiStack extends cdk.Stack {
       path: '/v1/health',
       methods: [apigwv2.HttpMethod.GET],
       integration: healthIntegration,
+    });
+
+    this.gameRegistryTable = new dynamodb.Table(this, 'GameRegistry', {
+      partitionKey: { name: 'keyHash', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    new AwsCustomResource(this, 'DevFixtureSeed', {
+      onCreate: {
+        service: 'DynamoDB',
+        action: 'putItem',
+        parameters: {
+          TableName: this.gameRegistryTable.tableName,
+          Item: {
+            keyHash: { S: DEV_FIXTURE_KEY_HASH },
+            gameId: { S: DEV_FIXTURE_GAME_ID },
+          },
+        },
+        physicalResourceId: PhysicalResourceId.of('dev-fixture-seed'),
+      },
+      policy: AwsCustomResourcePolicy.fromSdkCalls({
+        resources: [this.gameRegistryTable.tableArn],
+      }),
+    });
+
+    new cdk.CfnOutput(this, 'GameRegistryTableName', {
+      value: this.gameRegistryTable.tableName,
+      exportName: 'GameRegistryTableName',
+    });
+
+    new cdk.CfnOutput(this, 'GameRegistryTableArn', {
+      value: this.gameRegistryTable.tableArn,
+      exportName: 'GameRegistryTableArn',
     });
   }
 }

--- a/infra/cdk/test-fixtures/dev-game-key.ts
+++ b/infra/cdk/test-fixtures/dev-game-key.ts
@@ -1,0 +1,7 @@
+/**
+ * NON-PRODUCTION TEST FIXTURE ONLY.
+ * Plaintext SDK key for local/dev tests — never commit production keys.
+ * Format: turnur_sk_ + 32 lowercase hex characters (ADR-002).
+ */
+export const DEV_FIXTURE_PLAINTEXT_SDK_KEY =
+  'turnur_sk_00000000000000000000000000000000';


### PR DESCRIPTION
## Summary
- Add `GameRegistry` DynamoDB table with `keyHash` partition key and on-demand billing
- Seed dev fixture (`dev-fixture`) via CDK Custom Resource using hash-only storage
- Export table name/ARN stack outputs and shared `hashSdkKey` utility for #10

Closes #9

## Test plan
- [x] `npm run build && npm test && npm run synth` from `infra/cdk/`
- [x] Grep confirms no plaintext `turnur_sk_` outside `test-fixtures/`
- [x] CDK tests assert DynamoDB table PK and dev seed custom resource