### PR TITLE
Validate game SDK keys on protected HTTP API routes

### DIFF
--- a/infra/cdk/lib/game-auth/constants.ts
+++ b/infra/cdk/lib/game-auth/constants.ts
@@ -1,3 +1,9 @@
+/** ADR-002 SDK key prefix. */
+export const SDK_KEY_PREFIX = 'turnur_sk_';
+
+/** ADR-002: turnur_sk_ + exactly 32 lowercase hex characters. */
+export const SDK_KEY_FORMAT_REGEX = /^turnur_sk_[0-9a-f]{32}$/;
+
 /** Stable game id for the dev/test fixture row seeded in GameRegistry. */
 export const DEV_FIXTURE_GAME_ID = 'dev-fixture';
 

--- a/infra/cdk/lib/game-auth/game-auth-response.ts
+++ b/infra/cdk/lib/game-auth/game-auth-response.ts
@@ -1,0 +1,33 @@
+import type { APIGatewayProxyResultV2 } from 'aws-lambda';
+
+export type GameAuthErrorCode = 'game_auth_required' | 'game_auth_invalid';
+
+export type GameAuthErrorBody = {
+  code: GameAuthErrorCode;
+  message: string;
+  hint: string;
+};
+
+function jsonResponse(statusCode: number, body: GameAuthErrorBody): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+}
+
+export function buildGameAuthRequiredResponse(): APIGatewayProxyResultV2 {
+  return jsonResponse(401, {
+    code: 'game_auth_required',
+    message: 'Game SDK key required',
+    hint: 'Send Authorization: Bearer <sdk-key> with a valid turnur_sk_ key.',
+  });
+}
+
+export function buildGameAuthInvalidResponse(): APIGatewayProxyResultV2 {
+  return jsonResponse(401, {
+    code: 'game_auth_invalid',
+    message: 'Invalid game SDK key',
+    hint: 'Check the Authorization Bearer token format and that the key is registered.',
+  });
+}

--- a/infra/cdk/lib/game-auth/require-game-auth.test.ts
+++ b/infra/cdk/lib/game-auth/require-game-auth.test.ts
@@ -1,0 +1,156 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEV_FIXTURE_GAME_ID } from './constants';
+import { requireGameAuth } from './require-game-auth';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../../test-fixtures/dev-game-key';
+
+const TABLE_NAME = 'GameRegistryTest';
+
+function eventWithAuth(value: string | undefined): Pick<APIGatewayProxyEventV2, 'headers'> {
+  if (value === undefined) {
+    return { headers: {} };
+  }
+  return { headers: { authorization: value } };
+}
+
+function parseAuthBody(result: {
+  ok: false;
+  response: APIGatewayProxyResultV2;
+}): {
+  code: string;
+  message: string;
+  hint: string;
+} {
+  const response = result.response;
+  if (typeof response === 'string' || !response.body) {
+    throw new Error('expected structured auth error response');
+  }
+  return JSON.parse(response.body);
+}
+
+function authStatusCode(response: APIGatewayProxyResultV2): number {
+  if (typeof response === 'string') {
+    throw new Error('expected structured auth error response');
+  }
+  return response.statusCode ?? 0;
+}
+
+function authBody(response: APIGatewayProxyResultV2): string {
+  if (typeof response === 'string') {
+    throw new Error('expected structured auth error response');
+  }
+  return response.body ?? '';
+}
+
+describe('requireGameAuth', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+  });
+
+  const docClient = { send } as unknown as DynamoDBDocumentClient;
+
+  it('returns gameId for a valid registered SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } });
+
+    const result = await requireGameAuth(
+      eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      { tableName: TABLE_NAME, docClient },
+    );
+
+    expect(result).toEqual({ ok: true, context: { gameId: DEV_FIXTURE_GAME_ID } });
+    expect(send).toHaveBeenCalledWith(expect.any(GetCommand));
+  });
+
+  it('returns game_auth_required when Authorization is absent', async () => {
+    const result = await requireGameAuth(eventWithAuth(undefined), {
+      tableName: TABLE_NAME,
+      docClient,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('expected auth failure');
+    }
+    expect(authStatusCode(result.response)).toBe(401);
+    expect(parseAuthBody(result)).toMatchObject({ code: 'game_auth_required' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns game_auth_invalid for empty Bearer token', async () => {
+    const result = await requireGameAuth(eventWithAuth('Bearer '), {
+      tableName: TABLE_NAME,
+      docClient,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('expected auth failure');
+    }
+    expect(parseAuthBody(result)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns game_auth_invalid for non-Bearer scheme', async () => {
+    const result = await requireGameAuth(
+      eventWithAuth(`Basic ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      { tableName: TABLE_NAME, docClient },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('expected auth failure');
+    }
+    expect(parseAuthBody(result)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns game_auth_invalid for malformed SDK key without DynamoDB lookup', async () => {
+    const result = await requireGameAuth(eventWithAuth('Bearer turnur_sk_not-valid'), {
+      tableName: TABLE_NAME,
+      docClient,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('expected auth failure');
+    }
+    expect(parseAuthBody(result)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns game_auth_invalid when registry lookup misses', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await requireGameAuth(
+      eventWithAuth('Bearer turnur_sk_11111111111111111111111111111111'),
+      { tableName: TABLE_NAME, docClient },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('expected auth failure');
+    }
+    expect(parseAuthBody(result)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it('does not echo the presented token in error responses', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await requireGameAuth(
+      eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      { tableName: TABLE_NAME, docClient },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('expected auth failure');
+    }
+    expect(authBody(result.response)).not.toContain('turnur_sk_');
+    expect(authBody(result.response)).not.toContain('keyHash');
+  });
+});

--- a/infra/cdk/lib/game-auth/require-game-auth.ts
+++ b/infra/cdk/lib/game-auth/require-game-auth.ts
@@ -1,0 +1,86 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+
+import { SDK_KEY_FORMAT_REGEX } from './constants';
+import {
+  buildGameAuthInvalidResponse,
+  buildGameAuthRequiredResponse,
+} from './game-auth-response';
+import { hashSdkKey } from './hash-sdk-key';
+import type { GameAuthResult } from './types';
+
+const BEARER_PREFIX = 'Bearer ';
+
+type ParsedAuthorization =
+  | { kind: 'missing' }
+  | { kind: 'invalid' }
+  | { kind: 'token'; token: string };
+
+function authorizationHeader(
+  headers: APIGatewayProxyEventV2['headers'],
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  return headers.authorization ?? headers.Authorization;
+}
+
+function parseBearerToken(headerValue: string | undefined): ParsedAuthorization {
+  if (headerValue === undefined) {
+    return { kind: 'missing' };
+  }
+  if (!headerValue.startsWith(BEARER_PREFIX)) {
+    return { kind: 'invalid' };
+  }
+  const token = headerValue.slice(BEARER_PREFIX.length);
+  if (token.length === 0) {
+    return { kind: 'invalid' };
+  }
+  return { kind: 'token', token };
+}
+
+export type RequireGameAuthOptions = {
+  tableName?: string;
+  docClient?: DynamoDBDocumentClient;
+};
+
+export async function requireGameAuth(
+  event: Pick<APIGatewayProxyEventV2, 'headers'>,
+  options: RequireGameAuthOptions = {},
+): Promise<GameAuthResult> {
+  const parsed = parseBearerToken(authorizationHeader(event.headers));
+
+  if (parsed.kind === 'missing') {
+    return { ok: false, response: buildGameAuthRequiredResponse() };
+  }
+  if (parsed.kind === 'invalid') {
+    return { ok: false, response: buildGameAuthInvalidResponse() };
+  }
+  if (!SDK_KEY_FORMAT_REGEX.test(parsed.token)) {
+    return { ok: false, response: buildGameAuthInvalidResponse() };
+  }
+
+  const tableName = options.tableName ?? process.env.GAME_REGISTRY_TABLE_NAME;
+  if (!tableName) {
+    return { ok: false, response: buildGameAuthInvalidResponse() };
+  }
+
+  const docClient =
+    options.docClient ?? DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+  const keyHash = hashSdkKey(parsed.token);
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { keyHash },
+    }),
+  );
+
+  const gameId = result.Item?.gameId;
+  if (typeof gameId !== 'string' || gameId.length === 0) {
+    return { ok: false, response: buildGameAuthInvalidResponse() };
+  }
+
+  return { ok: true, context: { gameId } };
+}

--- a/infra/cdk/lib/game-auth/types.ts
+++ b/infra/cdk/lib/game-auth/types.ts
@@ -1,0 +1,9 @@
+import type { APIGatewayProxyResultV2 } from 'aws-lambda';
+
+export type GameAuthContext = {
+  gameId: string;
+};
+
+export type GameAuthResult =
+  | { ok: true; context: GameAuthContext }
+  | { ok: false; response: APIGatewayProxyResultV2 };

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -1,9 +1,22 @@
+import * as path from 'path';
+
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Construct } from 'constructs';
 import { describe, expect, it } from 'vitest';
 
 import { DEV_FIXTURE_GAME_ID, DEV_FIXTURE_KEY_HASH } from './game-auth/constants';
 import { TurnurApiStack } from './turnur-api-stack';
+
+class ProtectedFnProbeStack extends TurnurApiStack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    this.createProtectedNodejsFunction('AuthProbeFn', {
+      entry: path.join(__dirname, '../lambda/health-handler.ts'),
+      handler: 'handler',
+    });
+  }
+}
 
 describe('TurnurApiStack', () => {
   it('synthesizes HTTP API, Node 22 Lambda, and GET /v1/health route', () => {
@@ -54,5 +67,31 @@ describe('TurnurApiStack', () => {
 
     template.hasOutput('GameRegistryTableName', {});
     template.hasOutput('GameRegistryTableArn', {});
+  });
+
+  it('protected Lambda factory grants GameRegistry GetItem and sets env var', () => {
+    const app = new cdk.App();
+    const stack = new ProtectedFnProbeStack(app, 'TurnurApiStackProtectedFnTest');
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Runtime: 'nodejs22.x',
+      Environment: {
+        Variables: Match.objectLike({
+          GAME_REGISTRY_TABLE_NAME: Match.anyValue(),
+        }),
+      },
+    });
+
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'dynamodb:GetItem',
+            Effect: 'Allow',
+          }),
+        ]),
+      },
+    });
   });
 });

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -4,6 +4,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import {
@@ -83,5 +84,35 @@ export class TurnurApiStack extends cdk.Stack {
       value: this.gameRegistryTable.tableArn,
       exportName: 'GameRegistryTableArn',
     });
+  }
+
+  /** Protected Lambda factory: registry read + GAME_REGISTRY_TABLE_NAME for in-handler auth. */
+  createProtectedNodejsFunction(
+    id: string,
+    props: Pick<
+      lambdaNodejs.NodejsFunctionProps,
+      'entry' | 'handler' | 'environment' | 'description'
+    >,
+  ): lambdaNodejs.NodejsFunction {
+    const fn = new lambdaNodejs.NodejsFunction(this, id, {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      bundling: sharedLambdaBundle,
+      environment: {
+        ...props.environment,
+        GAME_REGISTRY_TABLE_NAME: this.gameRegistryTable.tableName,
+      },
+      entry: props.entry,
+      handler: props.handler,
+      description: props.description,
+    });
+
+    fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem'],
+        resources: [this.gameRegistryTable.tableArn],
+      }),
+    );
+
+    return fn;
   }
 }

--- a/infra/cdk/package-lock.json
+++ b/infra/cdk/package-lock.json
@@ -8,6 +8,8 @@
       "name": "@turnur/infra-cdk",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.758.0",
+        "@aws-sdk/lib-dynamodb": "^3.758.0",
         "aws-cdk-lib": "^2.173.4",
         "constructs": "^10.4.2"
       },
@@ -69,6 +71,358 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1118.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1118.0.tgz",
+      "integrity": "sha512-svEO204aN18SV433vZ1+VRCdRrMhQto52pTDOJwkwO5FcydmZa+Ld+lWu0k6OC50Ft4qJb1WrG2lsEno/++lGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.81",
+        "@aws-sdk/dynamodb-codec": "^3.973.44",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.30",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.81",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+      "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.44.tgz",
+      "integrity": "sha512-eo27HNeBqMAfy9JBQug6ErU6DeG8OmOH6ou8+KmX3/fWdTmWUsHsfisz2tEQOG+GJ57bBC7kC6AjKAjpcxU4QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1118.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1118.0.tgz",
+      "integrity": "sha512-xVluK5+wcrxJMWho3V5OKXBFxv1oriVOHprfMTds4kkUw0cPh1oOHIKEj8KP1m8F/dztFMVXfIEbvltxCMlCTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/util-dynamodb": "^3.996.9",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1118.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.30.tgz",
+      "integrity": "sha512-0hmD7/NG2NoVOVHvUb6rtY5POQYr+/9gdHvrYhIBA1zmCqKOBd5Gz3dL+iZ15FHOJbs/5kLplGoePc8PHTlzYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.9.tgz",
+      "integrity": "sha512-16x2tRvl7OYpZ0W/DdFJieFriD13+RvuRBDbe5sj/tCEfK86HSGd7I2s5j0ivz8p6KWGkS+5wKRO9OliJkjUOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1111.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -921,6 +1275,87 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
@@ -1373,6 +1808,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1594,6 +2035,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1619,6 +2069,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1880,6 +2336,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.6.3",

--- a/infra/cdk/package.json
+++ b/infra/cdk/package.json
@@ -21,6 +21,8 @@
     "vitest": "^3.0.2"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.758.0",
+    "@aws-sdk/lib-dynamodb": "^3.758.0",
     "aws-cdk-lib": "^2.173.4",
     "constructs": "^10.4.2"
   }


### PR DESCRIPTION
## Summary

- Add shared `lib/game-auth/` module with `requireGameAuth` that validates `Authorization: Bearer <sdk-key>` against the `GameRegistry` DynamoDB table (ADR-002 format check, SHA-256 hash lookup).
- Return structured **401** JSON with distinct `game_auth_required` vs `game_auth_invalid` codes; never log or echo plaintext keys.
- Extend `TurnurApiStack` with `createProtectedNodejsFunction` factory granting scoped `dynamodb:GetItem` and setting `GAME_REGISTRY_TABLE_NAME`.

Closes #10

## Test plan

- [x] `npm run build && npm test && npm run synth` exit 0 from `infra/cdk/`
- [x] `require-game-auth.test.ts` covers valid (mocked registry hit), missing header, empty Bearer, Basic scheme, malformed key, and unknown hash paths
- [x] `turnur-api-stack.test.ts` asserts health route stays unauthenticated; protected-fn IAM + env var
- [x] Grep: no logging of Authorization header or Bearer token in auth module
- [ ] CI passes on PR