### PR TITLE
Add GET /v1/game/me authenticated probe route

### DIFF
--- a/infra/cdk/lambda/game-me-handler.test.ts
+++ b/infra/cdk/lambda/game-me-handler.test.ts
@@ -1,0 +1,86 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEV_FIXTURE_GAME_ID } from '../lib/game-auth/constants';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../test-fixtures/dev-game-key';
+import { handler } from './game-me-handler';
+
+const TABLE_NAME = 'GameRegistryTest';
+
+function eventWithAuth(value: string | undefined): APIGatewayProxyEventV2 {
+  const headers = value === undefined ? {} : { authorization: value };
+  return {
+    routeKey: 'GET /v1/game/me',
+    headers,
+    requestContext: {
+      http: { method: 'GET' },
+    },
+  } as APIGatewayProxyEventV2;
+}
+
+function responseBody(result: APIGatewayProxyResultV2): Record<string, unknown> {
+  if (typeof result === 'string' || !result.body) {
+    throw new Error('expected structured response');
+  }
+  return JSON.parse(result.body);
+}
+
+function statusCode(result: APIGatewayProxyResultV2): number {
+  if (typeof result === 'string') {
+    throw new Error('expected structured response');
+  }
+  return result.statusCode ?? 0;
+}
+
+describe('game-me-handler', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+    process.env.GAME_REGISTRY_TABLE_NAME = TABLE_NAME;
+    vi.spyOn(DynamoDBDocumentClient, 'from').mockReturnValue({
+      send,
+    } as unknown as DynamoDBDocumentClient);
+  });
+
+  it('returns 200 with gameId for a valid dev-fixture SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } });
+
+    const result = await handler(
+      eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    expect(result).toMatchObject({
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+    expect(responseBody(result!)).toEqual({ gameId: DEV_FIXTURE_GAME_ID });
+    expect(JSON.stringify(responseBody(result!))).not.toContain('turnur_sk_');
+    expect(send).toHaveBeenCalledWith(expect.any(GetCommand));
+  });
+
+  it('returns 401 game_auth_required when Authorization is absent', async () => {
+    const result = await handler(eventWithAuth(undefined), {} as never, () => {});
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_required' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 game_auth_invalid for an unknown SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('Bearer turnur_sk_11111111111111111111111111111111'),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).toHaveBeenCalledOnce();
+  });
+});

--- a/infra/cdk/lambda/game-me-handler.ts
+++ b/infra/cdk/lambda/game-me-handler.ts
@@ -1,0 +1,23 @@
+/**
+ * GET /v1/game/me — authenticated probe; returns stable gameId for valid SDK keys.
+ */
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+
+import { requireGameAuth } from '../lib/game-auth/require-game-auth';
+
+export type GameMeResponseBody = { gameId: string };
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const auth = await requireGameAuth(event);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const body: GameMeResponseBody = { gameId: auth.context.gameId };
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+};

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -29,19 +29,32 @@ describe('TurnurApiStack', () => {
       Runtime: 'nodejs22.x',
     });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Route', 1);
+    template.resourceCountIs('AWS::ApiGatewayV2::Route', 2);
     template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
       RouteKey: 'GET /v1/health',
       AuthorizationType: 'NONE',
     });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'GET /v1/game/me',
+      AuthorizationType: 'NONE',
+    });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 1);
+    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 2);
     template.hasResourceProperties('AWS::ApiGatewayV2::Integration', {
       IntegrationType: 'AWS_PROXY',
       PayloadFormatVersion: '2.0',
     });
 
     template.resourceCountIs('AWS::ApiGatewayV2::Authorizer', 0);
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Runtime: 'nodejs22.x',
+      Environment: {
+        Variables: Match.objectLike({
+          GAME_REGISTRY_TABLE_NAME: Match.anyValue(),
+        }),
+      },
+    });
 
     const permissions = template.findResources('AWS::Lambda::Permission');
     expect(Object.keys(permissions).length).toBeGreaterThanOrEqual(1);

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -23,6 +23,7 @@ const sharedLambdaBundle = {
 export class TurnurApiStack extends cdk.Stack {
   public readonly httpApi: apigwv2.HttpApi;
   public readonly healthFunction: lambdaNodejs.NodejsFunction;
+  public readonly gameMeFunction: lambdaNodejs.NodejsFunction;
   public readonly gameRegistryTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -83,6 +84,23 @@ export class TurnurApiStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'GameRegistryTableArn', {
       value: this.gameRegistryTable.tableArn,
       exportName: 'GameRegistryTableArn',
+    });
+
+    this.gameMeFunction = this.createProtectedNodejsFunction('GameMeFn', {
+      entry: path.join(__dirname, '../lambda/game-me-handler.ts'),
+      handler: 'handler',
+      description: 'GET /v1/game/me — authenticated game identity probe',
+    });
+
+    const gameMeIntegration = new integrations.HttpLambdaIntegration(
+      'GameMeInt',
+      this.gameMeFunction,
+    );
+
+    this.httpApi.addRoutes({
+      path: '/v1/game/me',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: gameMeIntegration,
     });
   }
 


### PR DESCRIPTION
## Summary

- Add `GET /v1/game/me` Lambda handler that calls `requireGameAuth` and returns `{ gameId }` on success
- Register the route on `TurnurApiStack` via `createProtectedNodejsFunction` (in-handler auth; API Gateway `AuthorizationType: NONE`)
- Add Vitest handler tests (valid dev-fixture key, missing header, invalid key) and extend CDK stack tests for the second route

Closes #11

## Test plan

- [x] `npm run build && npm test && npm run synth` exit 0 from `infra/cdk/`
- [x] `game-me-handler.test.ts` covers valid (200 + `gameId`), missing (401 + `game_auth_required`), and invalid (401 + `game_auth_invalid`) paths
- [x] `turnur-api-stack.test.ts` asserts two routes, zero authorizers, and protected Lambda env/IAM
- [x] Handler does not log Authorization header or Bearer token