### PR TITLE
Document game authentication onboarding for integrators (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Identity, chat, rooms, and media stay on the host platform (RiffSync or anything
 ## Infrastructure
 
 AWS CDK workspace lives under [`infra/cdk/`](infra/cdk/README.md). See that README for Node 22 setup and verify commands (`npm ci`, `npm run build`, `npm test`, `npm run synth`).
+
+For game SDK key setup and verification (`GET /v1/health` → configure key → `GET /v1/game/me`), see [Game authentication onboarding](infra/cdk/README.md#game-authentication-onboarding) in the CDK README.

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -35,8 +35,160 @@ npm run synth
 | Method | Path | Auth | Response |
 | --- | --- | --- | --- |
 | `GET` | `/v1/health` | none (public liveness) | HTTP 200, `{ "ok": true }` |
+| `GET` | `/v1/game/me` | `Authorization: Bearer` SDK key | HTTP 200, `{ "gameId": "<string>" }`; HTTP 401 structured error |
 
 The health route confirms the control-plane Lambda and API Gateway wiring are present. It does not check downstream dependencies (DynamoDB, Cognito, etc.).
+
+## Game authentication onboarding
+
+Integrators can verify Turnur is reachable and that an SDK key is configured without reading source code. The path is:
+
+1. **`GET /v1/health`** — confirm the API is up (no auth).
+2. **Obtain and configure an SDK key** — store it in your runtime environment (for example `TURNUR_SDK_KEY`). Turnur does not yet expose key provisioning APIs; use the key issued for your game registration.
+3. **`GET /v1/game/me`** — authenticated probe that returns the stable `gameId` for your key.
+
+Set placeholders before running the examples below:
+
+```bash
+export TURNUR_BASE_URL="https://your-turnur-api.example.com"   # no trailing slash
+export TURNUR_SDK_KEY="turnur_sk_your32hexcharactershere000000" # your integrator key
+```
+
+**Do not log, commit, or paste SDK keys into public channels.** Use environment variables or a secrets manager in production.
+
+### Authentication model
+
+**Turnur authenticates games, not players.** Your game server presents an SDK key to identify itself to Turnur. Player identity, chat, rooms, and media stay on the host platform (RiffSync or any equivalent).
+
+SDK keys follow **ADR-002**: `turnur_sk_` plus exactly **32 lowercase hex characters**.
+
+Send the key on every protected request:
+
+```http
+Authorization: Bearer turnur_sk_<32 lowercase hex>
+```
+
+Do not pass SDK keys in query strings or request bodies.
+
+### Health check (unauthenticated)
+
+```bash
+curl -sS "$TURNUR_BASE_URL/v1/health"
+```
+
+Expected **200** response:
+
+```json
+{ "ok": true }
+```
+
+### Authenticated probe
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $TURNUR_SDK_KEY" \
+  "$TURNUR_BASE_URL/v1/game/me"
+```
+
+Expected **200** response:
+
+```json
+{ "gameId": "your-game-id" }
+```
+
+### Auth errors (401)
+
+Protected routes return structured JSON on failure:
+
+```json
+{ "code": "<string>", "message": "<string>", "hint": "<string>" }
+```
+
+| `code` | When |
+| --- | --- |
+| `game_auth_required` | `Authorization` header is missing |
+| `game_auth_invalid` | Header present but token is malformed, unknown, or not registered |
+
+**Missing header** — omit `Authorization`:
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" "$TURNUR_BASE_URL/v1/game/me"
+```
+
+Example **401** body:
+
+```json
+{
+  "code": "game_auth_required",
+  "message": "Game SDK key required",
+  "hint": "Send Authorization: Bearer <sdk-key> with a valid turnur_sk_ key."
+}
+```
+
+**Invalid key** — malformed or unregistered token:
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" \
+  -H "Authorization: Bearer turnur_sk_ffffffffffffffffffffffffffffffff" \
+  "$TURNUR_BASE_URL/v1/game/me"
+```
+
+Example **401** body:
+
+```json
+{
+  "code": "game_auth_invalid",
+  "message": "Invalid game SDK key",
+  "hint": "Check the Authorization Bearer token format and that the key is registered."
+}
+```
+
+### Dev stack fixture (non-production)
+
+> **NON-PRODUCTION ONLY.** The dev CDK stack seeds a test fixture key for local verification. Never use this key outside dev/test environments.
+
+| Plaintext key | Registered `gameId` |
+| --- | --- |
+| `turnur_sk_00000000000000000000000000000000` | `dev-fixture` |
+
+After deploying a dev stack, you can probe with:
+
+```bash
+export TURNUR_SDK_KEY="turnur_sk_00000000000000000000000000000000"
+curl -sS -H "Authorization: Bearer $TURNUR_SDK_KEY" "$TURNUR_BASE_URL/v1/game/me"
+# => { "gameId": "dev-fixture" }
+```
+
+### TypeScript SDK (optional)
+
+When [`packages/turnur-sdk/`](../../packages/turnur-sdk/) is available, the same probe is:
+
+```typescript
+import { createTurnurClient } from '@turnur/sdk';
+
+const client = createTurnurClient({
+  baseUrl: process.env.TURNUR_BASE_URL!,
+  apiKey: process.env.TURNUR_SDK_KEY!,
+});
+
+const { gameId } = await client.game.me();
+console.log(gameId);
+```
+
+On **401**, the client throws an error with the structured `code`, `message`, and `hint` fields.
+
+### Not yet implemented
+
+The following match-engine capabilities are not available over HTTP yet:
+
+- Host attach
+- Seats
+- Turns
+- Hidden views
+- Move log
+- Signed result
+
+Documenting them here sets expectations only; there are no routes for these flows today.
 
 ## Layout
 


### PR DESCRIPTION
## Summary

- Add **Game authentication onboarding** section to `infra/cdk/README.md` covering health check → SDK key configuration → `GET /v1/game/me` with copy-pasteable `curl` examples, auth header format, structured **401** JSON, games-not-players boundary, dev fixture banner, and not-yet-implemented list
- Extend HTTP API table with `GET /v1/game/me`
- Add root `README.md` pointer to the onboarding section
- Include optional TypeScript SDK snippet using `createTurnurClient({ baseUrl, apiKey }).game.me()`

Closes #13

## Test plan

- [x] Manual review: all AC bullets present in `infra/cdk/README.md` and root pointer
- [x] `grep` docs: no production SDK keys; dev fixture marked non-production
- [ ] Copy-paste `curl` blocks against a dev deploy (post-merge verification)