### PR TITLE
Add Match registry storage to TurnurApi stack

### DIFF
--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -60,15 +60,20 @@ describe('TurnurApiStack', () => {
     expect(Object.keys(permissions).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('synthesizes GameRegistry DynamoDB table and dev fixture seed', () => {
+  it('synthesizes GameRegistry and MatchRegistry DynamoDB tables and dev fixture seed', () => {
     const app = new cdk.App();
     const stack = new TurnurApiStack(app, 'TurnurApiStackGameRegistryTest');
     const template = Template.fromStack(stack);
 
-    template.resourceCountIs('AWS::DynamoDB::Table', 1);
+    template.resourceCountIs('AWS::DynamoDB::Table', 2);
     template.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [{ AttributeName: 'keyHash', KeyType: 'HASH' }],
       AttributeDefinitions: [{ AttributeName: 'keyHash', AttributeType: 'S' }],
+      BillingMode: 'PAY_PER_REQUEST',
+    });
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      KeySchema: [{ AttributeName: 'matchId', KeyType: 'HASH' }],
+      AttributeDefinitions: [{ AttributeName: 'matchId', AttributeType: 'S' }],
       BillingMode: 'PAY_PER_REQUEST',
     });
 
@@ -80,6 +85,8 @@ describe('TurnurApiStack', () => {
 
     template.hasOutput('GameRegistryTableName', {});
     template.hasOutput('GameRegistryTableArn', {});
+    template.hasOutput('MatchRegistryTableName', {});
+    template.hasOutput('MatchRegistryTableArn', {});
   });
 
   it('protected Lambda factory grants GameRegistry GetItem and sets env var', () => {

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -25,6 +25,7 @@ export class TurnurApiStack extends cdk.Stack {
   public readonly healthFunction: lambdaNodejs.NodejsFunction;
   public readonly gameMeFunction: lambdaNodejs.NodejsFunction;
   public readonly gameRegistryTable: dynamodb.Table;
+  public readonly matchRegistryTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
@@ -84,6 +85,22 @@ export class TurnurApiStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'GameRegistryTableArn', {
       value: this.gameRegistryTable.tableArn,
       exportName: 'GameRegistryTableArn',
+    });
+
+    this.matchRegistryTable = new dynamodb.Table(this, 'MatchRegistry', {
+      partitionKey: { name: 'matchId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    new cdk.CfnOutput(this, 'MatchRegistryTableName', {
+      value: this.matchRegistryTable.tableName,
+      exportName: 'MatchRegistryTableName',
+    });
+
+    new cdk.CfnOutput(this, 'MatchRegistryTableArn', {
+      value: this.matchRegistryTable.tableArn,
+      exportName: 'MatchRegistryTableArn',
     });
 
     this.gameMeFunction = this.createProtectedNodejsFunction('GameMeFn', {


### PR DESCRIPTION
## Summary

- Adds `MatchRegistry` DynamoDB table to `TurnurApiStack` with partition key `matchId` (String), on-demand billing, and dev-friendly removal policy — mirroring existing `GameRegistry` patterns
- Exports `MatchRegistryTableName` and `MatchRegistryTableArn` stack outputs for downstream attach routes (#20–#21)
- Extends CDK assertion tests for table schema (PK `matchId`, `PAY_PER_REQUEST`) and output wiring

Closes #19

## Test plan

- [x] `npm run build` exits 0 from `infra/cdk/`
- [x] `npm test` exits 0 — CDK tests assert two DynamoDB tables and `MatchRegistryTableName` output
- [x] `npm run synth` exits 0 — template shows `GameRegistry` + `MatchRegistry`; no new HTTP routes beyond `/v1/health` and `/v1/game/me`