### PR TITLE
Add POST /v1/matches attach route

### DIFF
--- a/infra/cdk/lambda/matches-attach-handler.test.ts
+++ b/infra/cdk/lambda/matches-attach-handler.test.ts
@@ -1,0 +1,111 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEV_FIXTURE_GAME_ID } from '../lib/game-auth/constants';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../test-fixtures/dev-game-key';
+import { handler } from './matches-attach-handler';
+
+const GAME_TABLE_NAME = 'GameRegistryTest';
+const MATCH_TABLE_NAME = 'MatchRegistryTest';
+
+function eventWithAuth(value: string | undefined): APIGatewayProxyEventV2 {
+  const headers = value === undefined ? {} : { authorization: value };
+  return {
+    routeKey: 'POST /v1/matches',
+    headers,
+    requestContext: {
+      http: { method: 'POST' },
+    },
+  } as APIGatewayProxyEventV2;
+}
+
+function responseBody(result: APIGatewayProxyResultV2): Record<string, unknown> {
+  if (typeof result === 'string' || !result.body) {
+    throw new Error('expected structured response');
+  }
+  return JSON.parse(result.body);
+}
+
+function statusCode(result: APIGatewayProxyResultV2): number {
+  if (typeof result === 'string') {
+    throw new Error('expected structured response');
+  }
+  return result.statusCode ?? 0;
+}
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('matches-attach-handler', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+    process.env.GAME_REGISTRY_TABLE_NAME = GAME_TABLE_NAME;
+    process.env.MATCH_REGISTRY_TABLE_NAME = MATCH_TABLE_NAME;
+    vi.spyOn(DynamoDBDocumentClient, 'from').mockReturnValue({
+      send,
+    } as unknown as DynamoDBDocumentClient);
+  });
+
+  it('returns 201 with matchId for a valid dev-fixture SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } });
+    send.mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    expect(result).toMatchObject({
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+    const body = responseBody(result!);
+    expect(body).toEqual({ matchId: expect.any(String) });
+    expect(body.matchId).toMatch(UUID_V4_REGEX);
+    expect(Object.keys(body)).toEqual(['matchId']);
+    expect(JSON.stringify(body)).not.toContain('turnur_sk_');
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenNthCalledWith(1, expect.any(GetCommand));
+    expect(send).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          TableName: MATCH_TABLE_NAME,
+          Item: expect.objectContaining({
+            matchId: body.matchId,
+            gameId: DEV_FIXTURE_GAME_ID,
+            status: 'created',
+            createdAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('returns 401 game_auth_required when Authorization is absent', async () => {
+    const result = await handler(eventWithAuth(undefined), {} as never, () => {});
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_required' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 game_auth_invalid for an unknown SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('Bearer turnur_sk_11111111111111111111111111111111'),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).toHaveBeenCalledOnce();
+  });
+});

--- a/infra/cdk/lambda/matches-attach-handler.ts
+++ b/infra/cdk/lambda/matches-attach-handler.ts
@@ -1,0 +1,46 @@
+/**
+ * POST /v1/matches — attach (create) a match; returns server-generated matchId.
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { randomUUID } from 'crypto';
+
+import { requireGameAuth } from '../lib/game-auth/require-game-auth';
+
+export type MatchesAttachResponseBody = { matchId: string };
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const auth = await requireGameAuth(event);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const matchId = randomUUID();
+  const createdAt = new Date().toISOString();
+  const tableName = process.env.MATCH_REGISTRY_TABLE_NAME;
+  if (!tableName) {
+    throw new Error('MATCH_REGISTRY_TABLE_NAME is not configured');
+  }
+
+  const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+  await docClient.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: {
+        matchId,
+        gameId: auth.context.gameId,
+        status: 'created',
+        createdAt,
+      },
+    }),
+  );
+
+  const body: MatchesAttachResponseBody = { matchId };
+
+  return {
+    statusCode: 201,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+};

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -18,6 +18,17 @@ class ProtectedFnProbeStack extends TurnurApiStack {
   }
 }
 
+class MatchRegistryWriteProbeStack extends TurnurApiStack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    this.createProtectedNodejsFunction('MatchWriteProbeFn', {
+      entry: path.join(__dirname, '../lambda/health-handler.ts'),
+      handler: 'handler',
+      matchRegistryWrite: true,
+    });
+  }
+}
+
 describe('TurnurApiStack', () => {
   it('synthesizes HTTP API, Node 22 Lambda, and GET /v1/health route', () => {
     const app = new cdk.App();
@@ -29,7 +40,7 @@ describe('TurnurApiStack', () => {
       Runtime: 'nodejs22.x',
     });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Route', 2);
+    template.resourceCountIs('AWS::ApiGatewayV2::Route', 3);
     template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
       RouteKey: 'GET /v1/health',
       AuthorizationType: 'NONE',
@@ -38,8 +49,12 @@ describe('TurnurApiStack', () => {
       RouteKey: 'GET /v1/game/me',
       AuthorizationType: 'NONE',
     });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'POST /v1/matches',
+      AuthorizationType: 'NONE',
+    });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 2);
+    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 3);
     template.hasResourceProperties('AWS::ApiGatewayV2::Integration', {
       IntegrationType: 'AWS_PROXY',
       PayloadFormatVersion: '2.0',
@@ -52,6 +67,16 @@ describe('TurnurApiStack', () => {
       Environment: {
         Variables: Match.objectLike({
           GAME_REGISTRY_TABLE_NAME: Match.anyValue(),
+        }),
+      },
+    });
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Runtime: 'nodejs22.x',
+      Environment: {
+        Variables: Match.objectLike({
+          GAME_REGISTRY_TABLE_NAME: Match.anyValue(),
+          MATCH_REGISTRY_TABLE_NAME: Match.anyValue(),
         }),
       },
     });
@@ -108,6 +133,36 @@ describe('TurnurApiStack', () => {
         Statement: Match.arrayWith([
           Match.objectLike({
             Action: 'dynamodb:GetItem',
+            Effect: 'Allow',
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('protected Lambda factory with matchRegistryWrite grants PutItem and sets env var', () => {
+    const app = new cdk.App();
+    const stack = new MatchRegistryWriteProbeStack(
+      app,
+      'TurnurApiStackMatchRegistryWriteTest',
+    );
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Runtime: 'nodejs22.x',
+      Environment: {
+        Variables: Match.objectLike({
+          GAME_REGISTRY_TABLE_NAME: Match.anyValue(),
+          MATCH_REGISTRY_TABLE_NAME: Match.anyValue(),
+        }),
+      },
+    });
+
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'dynamodb:PutItem',
             Effect: 'Allow',
           }),
         ]),

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -24,6 +24,7 @@ export class TurnurApiStack extends cdk.Stack {
   public readonly httpApi: apigwv2.HttpApi;
   public readonly healthFunction: lambdaNodejs.NodejsFunction;
   public readonly gameMeFunction: lambdaNodejs.NodejsFunction;
+  public readonly matchesAttachFunction: lambdaNodejs.NodejsFunction;
   public readonly gameRegistryTable: dynamodb.Table;
   public readonly matchRegistryTable: dynamodb.Table;
 
@@ -119,6 +120,24 @@ export class TurnurApiStack extends cdk.Stack {
       methods: [apigwv2.HttpMethod.GET],
       integration: gameMeIntegration,
     });
+
+    this.matchesAttachFunction = this.createProtectedNodejsFunction('MatchesAttachFn', {
+      entry: path.join(__dirname, '../lambda/matches-attach-handler.ts'),
+      handler: 'handler',
+      description: 'POST /v1/matches — attach (create) a match',
+      matchRegistryWrite: true,
+    });
+
+    const matchesAttachIntegration = new integrations.HttpLambdaIntegration(
+      'MatchesAttachInt',
+      this.matchesAttachFunction,
+    );
+
+    this.httpApi.addRoutes({
+      path: '/v1/matches',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: matchesAttachIntegration,
+    });
   }
 
   /** Protected Lambda factory: registry read + GAME_REGISTRY_TABLE_NAME for in-handler auth. */
@@ -127,15 +146,20 @@ export class TurnurApiStack extends cdk.Stack {
     props: Pick<
       lambdaNodejs.NodejsFunctionProps,
       'entry' | 'handler' | 'environment' | 'description'
-    >,
+    > & { matchRegistryWrite?: boolean },
   ): lambdaNodejs.NodejsFunction {
+    const environment: Record<string, string> = {
+      ...props.environment,
+      GAME_REGISTRY_TABLE_NAME: this.gameRegistryTable.tableName,
+    };
+    if (props.matchRegistryWrite) {
+      environment.MATCH_REGISTRY_TABLE_NAME = this.matchRegistryTable.tableName;
+    }
+
     const fn = new lambdaNodejs.NodejsFunction(this, id, {
       runtime: lambda.Runtime.NODEJS_22_X,
       bundling: sharedLambdaBundle,
-      environment: {
-        ...props.environment,
-        GAME_REGISTRY_TABLE_NAME: this.gameRegistryTable.tableName,
-      },
+      environment,
       entry: props.entry,
       handler: props.handler,
       description: props.description,
@@ -147,6 +171,15 @@ export class TurnurApiStack extends cdk.Stack {
         resources: [this.gameRegistryTable.tableArn],
       }),
     );
+
+    if (props.matchRegistryWrite) {
+      fn.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ['dynamodb:PutItem'],
+          resources: [this.matchRegistryTable.tableArn],
+        }),
+      );
+    }
 
     return fn;
   }


### PR DESCRIPTION
## Summary

- Add `POST /v1/matches` Lambda handler with game SDK key auth via `requireGameAuth`
- Persist match metadata to `MatchRegistry` (`matchId`, `gameId`, `status: "created"`, `createdAt`) and return **201** `{ matchId }`
- Extend `createProtectedNodejsFunction` with optional `matchRegistryWrite` for `MATCH_REGISTRY_TABLE_NAME` env and `dynamodb:PutItem` IAM

Closes #20

## Test plan

- [x] `npm run build`, `npm test`, and `npm run synth` pass from `infra/cdk/`
- [x] Handler tests: 401 `game_auth_required`, 401 `game_auth_invalid`, 201 with UUID `matchId` and correct PutItem payload
- [x] CDK tests: `POST /v1/matches` route, `MATCH_REGISTRY_TABLE_NAME` env, `dynamodb:PutItem` on MatchRegistry
- [x] Synth template shows three HTTP routes: `GET /v1/health`, `GET /v1/game/me`, `POST /v1/matches`