### PR TITLE
Add GET /v1/matches/{matchId} probe route

### DIFF
--- a/infra/cdk/lambda/matches-probe-handler.test.ts
+++ b/infra/cdk/lambda/matches-probe-handler.test.ts
@@ -1,0 +1,160 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEV_FIXTURE_GAME_ID } from '../lib/game-auth/constants';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../test-fixtures/dev-game-key';
+import { handler } from './matches-probe-handler';
+
+const GAME_TABLE_NAME = 'GameRegistryTest';
+const MATCH_TABLE_NAME = 'MatchRegistryTest';
+const MATCH_ID = 'aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee';
+const OTHER_GAME_ID = 'game_other_00000000000000000000000000000000';
+
+function eventWithAuth(
+  value: string | undefined,
+  matchId: string = MATCH_ID,
+): APIGatewayProxyEventV2 {
+  const headers = value === undefined ? {} : { authorization: value };
+  return {
+    routeKey: 'GET /v1/matches/{matchId}',
+    headers,
+    pathParameters: { matchId },
+    requestContext: {
+      http: { method: 'GET' },
+    },
+  } as APIGatewayProxyEventV2;
+}
+
+function responseBody(result: APIGatewayProxyResultV2): Record<string, unknown> {
+  if (typeof result === 'string' || !result.body) {
+    throw new Error('expected structured response');
+  }
+  return JSON.parse(result.body);
+}
+
+function statusCode(result: APIGatewayProxyResultV2): number {
+  if (typeof result === 'string') {
+    throw new Error('expected structured response');
+  }
+  return result.statusCode ?? 0;
+}
+
+describe('matches-probe-handler', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+    process.env.GAME_REGISTRY_TABLE_NAME = GAME_TABLE_NAME;
+    process.env.MATCH_REGISTRY_TABLE_NAME = MATCH_TABLE_NAME;
+    vi.spyOn(DynamoDBDocumentClient, 'from').mockReturnValue({
+      send,
+    } as unknown as DynamoDBDocumentClient);
+  });
+
+  it('returns 200 with match metadata for a valid dev-fixture SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } });
+    send.mockResolvedValueOnce({
+      Item: {
+        matchId: MATCH_ID,
+        gameId: DEV_FIXTURE_GAME_ID,
+        status: 'created',
+        createdAt: '2026-08-27T12:00:00.000Z',
+      },
+    });
+
+    const result = await handler(
+      eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    expect(result).toMatchObject({
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+    expect(responseBody(result!)).toEqual({
+      matchId: MATCH_ID,
+      status: 'created',
+      createdAt: '2026-08-27T12:00:00.000Z',
+    });
+    expect(Object.keys(responseBody(result!))).toEqual(['matchId', 'status', 'createdAt']);
+    expect(JSON.stringify(responseBody(result!))).not.toContain('turnur_sk_');
+    expect(JSON.stringify(responseBody(result!))).not.toContain(DEV_FIXTURE_GAME_ID);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenNthCalledWith(1, expect.any(GetCommand));
+    expect(send).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          TableName: MATCH_TABLE_NAME,
+          Key: { matchId: MATCH_ID },
+        }),
+      }),
+    );
+  });
+
+  it('returns 401 game_auth_required when Authorization is absent', async () => {
+    const result = await handler(eventWithAuth(undefined), {} as never, () => {});
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_required' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 game_auth_invalid for an unknown SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('Bearer turnur_sk_11111111111111111111111111111111'),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it('returns 404 match_not_found when match item is absent', async () => {
+    send.mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } });
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(404);
+    expect(responseBody(result!)).toMatchObject({ code: 'match_not_found' });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 403 match_forbidden when match belongs to another game', async () => {
+    send.mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } });
+    send.mockResolvedValueOnce({
+      Item: {
+        matchId: MATCH_ID,
+        gameId: OTHER_GAME_ID,
+        status: 'created',
+        createdAt: '2026-08-27T12:00:00.000Z',
+      },
+    });
+
+    const result = await handler(
+      eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(403);
+    const body = responseBody(result!);
+    expect(body).toMatchObject({ code: 'match_forbidden' });
+    expect(body).not.toHaveProperty('status');
+    expect(body).not.toHaveProperty('createdAt');
+    expect(body).not.toHaveProperty('matchId');
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/infra/cdk/lambda/matches-probe-handler.ts
+++ b/infra/cdk/lambda/matches-probe-handler.ts
@@ -1,0 +1,95 @@
+/**
+ * GET /v1/matches/{matchId} — read probe; returns match metadata when owned by authenticated game.
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+
+import { requireGameAuth } from '../lib/game-auth/require-game-auth';
+
+export type MatchesProbeResponseBody = {
+  matchId: string;
+  status: string;
+  createdAt: string;
+};
+
+type MatchProbeErrorCode = 'match_not_found' | 'match_forbidden';
+
+type MatchProbeErrorBody = {
+  code: MatchProbeErrorCode;
+  message: string;
+  hint: string;
+};
+
+function matchErrorResponse(
+  statusCode: number,
+  body: MatchProbeErrorBody,
+): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+}
+
+function buildMatchNotFoundResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(404, {
+    code: 'match_not_found',
+    message: 'Match not found',
+    hint: 'Verify the matchId exists and was created via POST /v1/matches for your game.',
+  });
+}
+
+function buildMatchForbiddenResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(403, {
+    code: 'match_forbidden',
+    message: 'Match belongs to another game',
+    hint: 'Use the SDK key for the game that created this match.',
+  });
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const auth = await requireGameAuth(event);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const matchId = event.pathParameters?.matchId;
+  if (!matchId) {
+    return buildMatchNotFoundResponse();
+  }
+
+  const tableName = process.env.MATCH_REGISTRY_TABLE_NAME;
+  if (!tableName) {
+    throw new Error('MATCH_REGISTRY_TABLE_NAME is not configured');
+  }
+
+  const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { matchId },
+    }),
+  );
+
+  if (!result.Item) {
+    return buildMatchNotFoundResponse();
+  }
+
+  const { gameId, status, createdAt } = result.Item;
+  if (gameId !== auth.context.gameId) {
+    return buildMatchForbiddenResponse();
+  }
+
+  const body: MatchesProbeResponseBody = {
+    matchId,
+    status: String(status),
+    createdAt: String(createdAt),
+  };
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+};

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -29,6 +29,17 @@ class MatchRegistryWriteProbeStack extends TurnurApiStack {
   }
 }
 
+class MatchRegistryReadProbeStack extends TurnurApiStack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    this.createProtectedNodejsFunction('MatchReadProbeFn', {
+      entry: path.join(__dirname, '../lambda/health-handler.ts'),
+      handler: 'handler',
+      matchRegistryRead: true,
+    });
+  }
+}
+
 describe('TurnurApiStack', () => {
   it('synthesizes HTTP API, Node 22 Lambda, and GET /v1/health route', () => {
     const app = new cdk.App();
@@ -40,7 +51,7 @@ describe('TurnurApiStack', () => {
       Runtime: 'nodejs22.x',
     });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Route', 3);
+    template.resourceCountIs('AWS::ApiGatewayV2::Route', 4);
     template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
       RouteKey: 'GET /v1/health',
       AuthorizationType: 'NONE',
@@ -53,8 +64,12 @@ describe('TurnurApiStack', () => {
       RouteKey: 'POST /v1/matches',
       AuthorizationType: 'NONE',
     });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'GET /v1/matches/{matchId}',
+      AuthorizationType: 'NONE',
+    });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 3);
+    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 4);
     template.hasResourceProperties('AWS::ApiGatewayV2::Integration', {
       IntegrationType: 'AWS_PROXY',
       PayloadFormatVersion: '2.0',
@@ -168,5 +183,51 @@ describe('TurnurApiStack', () => {
         ]),
       },
     });
+  });
+
+  it('protected Lambda factory with matchRegistryRead grants GetItem and sets env var', () => {
+    const app = new cdk.App();
+    const stack = new MatchRegistryReadProbeStack(
+      app,
+      'TurnurApiStackMatchRegistryReadTest',
+    );
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Runtime: 'nodejs22.x',
+      Environment: {
+        Variables: Match.objectLike({
+          GAME_REGISTRY_TABLE_NAME: Match.anyValue(),
+          MATCH_REGISTRY_TABLE_NAME: Match.anyValue(),
+        }),
+      },
+    });
+
+    const policies = template.findResources('AWS::IAM::Policy');
+    const getItemOnMatchRegistry = Object.values(policies).some((policy) => {
+      const statements = policy.Properties?.PolicyDocument?.Statement ?? [];
+      return statements.some(
+        (statement: { Action?: string | string[]; Resource?: string | string[] }) => {
+          const actions = Array.isArray(statement.Action)
+            ? statement.Action
+            : [statement.Action];
+          if (!actions.includes('dynamodb:GetItem')) {
+            return false;
+          }
+          const resources = Array.isArray(statement.Resource)
+            ? statement.Resource
+            : [statement.Resource];
+          return resources.some(
+            (resource) =>
+              typeof resource === 'object' &&
+              resource !== null &&
+              'Fn::GetAtt' in resource &&
+              Array.isArray((resource as { 'Fn::GetAtt': string[] })['Fn::GetAtt']) &&
+              (resource as { 'Fn::GetAtt': string[] })['Fn::GetAtt'][0].includes('MatchRegistry'),
+          );
+        },
+      );
+    });
+    expect(getItemOnMatchRegistry).toBe(true);
   });
 });

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -25,6 +25,7 @@ export class TurnurApiStack extends cdk.Stack {
   public readonly healthFunction: lambdaNodejs.NodejsFunction;
   public readonly gameMeFunction: lambdaNodejs.NodejsFunction;
   public readonly matchesAttachFunction: lambdaNodejs.NodejsFunction;
+  public readonly matchesProbeFunction: lambdaNodejs.NodejsFunction;
   public readonly gameRegistryTable: dynamodb.Table;
   public readonly matchRegistryTable: dynamodb.Table;
 
@@ -138,6 +139,24 @@ export class TurnurApiStack extends cdk.Stack {
       methods: [apigwv2.HttpMethod.POST],
       integration: matchesAttachIntegration,
     });
+
+    this.matchesProbeFunction = this.createProtectedNodejsFunction('MatchesProbeFn', {
+      entry: path.join(__dirname, '../lambda/matches-probe-handler.ts'),
+      handler: 'handler',
+      description: 'GET /v1/matches/{matchId} — read probe for match metadata',
+      matchRegistryRead: true,
+    });
+
+    const matchesProbeIntegration = new integrations.HttpLambdaIntegration(
+      'MatchesProbeInt',
+      this.matchesProbeFunction,
+    );
+
+    this.httpApi.addRoutes({
+      path: '/v1/matches/{matchId}',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: matchesProbeIntegration,
+    });
   }
 
   /** Protected Lambda factory: registry read + GAME_REGISTRY_TABLE_NAME for in-handler auth. */
@@ -146,13 +165,13 @@ export class TurnurApiStack extends cdk.Stack {
     props: Pick<
       lambdaNodejs.NodejsFunctionProps,
       'entry' | 'handler' | 'environment' | 'description'
-    > & { matchRegistryWrite?: boolean },
+    > & { matchRegistryWrite?: boolean; matchRegistryRead?: boolean },
   ): lambdaNodejs.NodejsFunction {
     const environment: Record<string, string> = {
       ...props.environment,
       GAME_REGISTRY_TABLE_NAME: this.gameRegistryTable.tableName,
     };
-    if (props.matchRegistryWrite) {
+    if (props.matchRegistryWrite || props.matchRegistryRead) {
       environment.MATCH_REGISTRY_TABLE_NAME = this.matchRegistryTable.tableName;
     }
 
@@ -176,6 +195,15 @@ export class TurnurApiStack extends cdk.Stack {
       fn.addToRolePolicy(
         new iam.PolicyStatement({
           actions: ['dynamodb:PutItem'],
+          resources: [this.matchRegistryTable.tableArn],
+        }),
+      );
+    }
+
+    if (props.matchRegistryRead) {
+      fn.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ['dynamodb:GetItem'],
           resources: [this.matchRegistryTable.tableArn],
         }),
       );


### PR DESCRIPTION
## Summary

- Add `GET /v1/matches/{matchId}` Lambda handler with game SDK key auth via `requireGameAuth`
- Read match metadata from `MatchRegistry` (GetItem); return **200** `{ matchId, status, createdAt }` when owned by authenticated game
- Return **404** `match_not_found` for unknown matches and **403** `match_forbidden` for cross-game access (no metadata leak)
- Extend `createProtectedNodejsFunction` with `matchRegistryRead` for GetItem IAM and env wiring

Closes #21

## Test plan

- [x] `npm run build`, `npm test`, and `npm run synth` pass from `infra/cdk/`
- [x] Handler tests: 401 auth paths, 200 success, 404 not found, 403 wrong game
- [x] CDK tests: fourth route `GET /v1/matches/{matchId}`, probe Lambda env, GetItem IAM on MatchRegistry
- [x] Synth shows four HTTP routes: health, game/me, POST matches, GET matches/{matchId}