### PR TITLE
Add TypeScript SDK match attach and get methods

### DIFF
--- a/packages/turnur-sdk/src/client.test.ts
+++ b/packages/turnur-sdk/src/client.test.ts
@@ -86,3 +86,197 @@ describe('createTurnurClient', () => {
     });
   });
 });
+
+describe('createTurnurClient.match', () => {
+  it('sends Authorization Bearer header on match.create', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ matchId: 'match-123' }), { status: 201 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await client.match.create();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/v1/matches`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+    expect(init.headers).toMatchObject({
+      Authorization: `Bearer ${API_KEY}`,
+      Accept: 'application/json',
+    });
+  });
+
+  it('returns matchId on 201 response from match.create', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ matchId: '550e8400-e29b-41d4-a716-446655440000' }), {
+          status: 201,
+        }),
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await expect(client.match.create()).resolves.toEqual({
+      matchId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+  });
+
+  it('sends Authorization Bearer header on match.get', async () => {
+    const matchId = '550e8400-e29b-41d4-a716-446655440000';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          matchId,
+          status: 'created',
+          createdAt: '2026-08-27T12:00:00.000Z',
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await client.match.get(matchId);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/v1/matches/${encodeURIComponent(matchId)}`);
+    expect(init.method).toBe('GET');
+    expect(init.headers).toMatchObject({
+      Authorization: `Bearer ${API_KEY}`,
+      Accept: 'application/json',
+    });
+  });
+
+  it('URL-encodes matchId in match.get path', async () => {
+    const matchId = 'match/with/slashes';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          matchId,
+          status: 'created',
+          createdAt: '2026-08-27T12:00:00.000Z',
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await client.match.get(matchId);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(`${BASE_URL}/v1/matches/${encodeURIComponent(matchId)}`);
+  });
+
+  it('returns match fields on 200 response from match.get', async () => {
+    const matchId = '550e8400-e29b-41d4-a716-446655440000';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            matchId,
+            status: 'created',
+            createdAt: '2026-08-27T12:00:00.000Z',
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await expect(client.match.get(matchId)).resolves.toEqual({
+      matchId,
+      status: 'created',
+      createdAt: '2026-08-27T12:00:00.000Z',
+    });
+  });
+
+  it('throws TurnurApiError with code and message on 401 from match.create', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 'game_auth_invalid',
+            message: 'Invalid game SDK key',
+          }),
+          { status: 401 },
+        ),
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.create()).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      const apiError = error as TurnurApiError;
+      expect(apiError.status).toBe(401);
+      expect(apiError.code).toBe('game_auth_invalid');
+      expect(apiError.message).toBe('Invalid game SDK key');
+      expect(String(apiError)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+
+  it('throws TurnurApiError with code and message on 403 from match.get', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 'match_forbidden',
+            message: 'Match belongs to another game',
+            hint: 'Use the SDK key for the game that created this match.',
+          }),
+          { status: 403 },
+        ),
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.get('some-match-id')).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      const apiError = error as TurnurApiError;
+      expect(apiError.status).toBe(403);
+      expect(apiError.code).toBe('match_forbidden');
+      expect(apiError.message).toBe('Match belongs to another game');
+      expect(apiError.hint).toBe('Use the SDK key for the game that created this match.');
+      expect(String(apiError)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+
+  it('throws TurnurApiError with code and message on 404 from match.get', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 'match_not_found',
+            message: 'Match not found',
+            hint: 'Verify the matchId exists and was created via POST /v1/matches for your game.',
+          }),
+          { status: 404 },
+        ),
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.get('missing-match-id')).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      const apiError = error as TurnurApiError;
+      expect(apiError.status).toBe(404);
+      expect(apiError.code).toBe('match_not_found');
+      expect(apiError.message).toBe('Match not found');
+      expect(String(apiError)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+});

--- a/packages/turnur-sdk/src/client.ts
+++ b/packages/turnur-sdk/src/client.ts
@@ -1,10 +1,24 @@
-import { authenticatedGet, throwUnauthorized } from './http.js';
+import {
+  authenticatedGet,
+  authenticatedPost,
+  throwStructuredError,
+  throwUnauthorized,
+} from './http.js';
 import { TurnurApiError } from './errors.js';
-import type { GameMeResponse, TurnurClientConfig } from './types.js';
+import type {
+  GameMeResponse,
+  MatchCreateResponse,
+  MatchGetResponse,
+  TurnurClientConfig,
+} from './types.js';
 
 export type TurnurClient = {
   game: {
     me(): Promise<GameMeResponse>;
+  };
+  match: {
+    create(): Promise<MatchCreateResponse>;
+    get(matchId: string): Promise<MatchGetResponse>;
   };
 };
 
@@ -29,6 +43,62 @@ export function createTurnurClient(config: TurnurClientConfig): TurnurClient {
         }
 
         return { gameId: (body as GameMeResponse).gameId };
+      },
+    },
+    match: {
+      async create(): Promise<MatchCreateResponse> {
+        const { status, body } = await authenticatedPost(baseUrl, apiKey, '/v1/matches');
+
+        if (status === 401) {
+          throwUnauthorized(body);
+        }
+
+        if (status === 403 || status === 404) {
+          throwStructuredError(status, body);
+        }
+
+        if (status !== 201) {
+          throw new TurnurApiError(status, `Request failed with status ${status}`);
+        }
+
+        if (!body || typeof (body as MatchCreateResponse).matchId !== 'string') {
+          throw new TurnurApiError(status, 'Invalid response: missing matchId');
+        }
+
+        return { matchId: (body as MatchCreateResponse).matchId };
+      },
+
+      async get(matchId: string): Promise<MatchGetResponse> {
+        const path = `/v1/matches/${encodeURIComponent(matchId)}`;
+        const { status, body } = await authenticatedGet(baseUrl, apiKey, path);
+
+        if (status === 401) {
+          throwUnauthorized(body);
+        }
+
+        if (status === 403 || status === 404) {
+          throwStructuredError(status, body);
+        }
+
+        if (status !== 200) {
+          throw new TurnurApiError(status, `Request failed with status ${status}`);
+        }
+
+        const response = body as MatchGetResponse;
+        if (
+          !body ||
+          typeof response.matchId !== 'string' ||
+          typeof response.status !== 'string' ||
+          typeof response.createdAt !== 'string'
+        ) {
+          throw new TurnurApiError(status, 'Invalid response: missing match fields');
+        }
+
+        return {
+          matchId: response.matchId,
+          status: response.status,
+          createdAt: response.createdAt,
+        };
       },
     },
   };

--- a/packages/turnur-sdk/src/http.ts
+++ b/packages/turnur-sdk/src/http.ts
@@ -30,6 +30,41 @@ export async function authenticatedGet(
   return { status: response.status, body };
 }
 
+export async function authenticatedPost(
+  baseUrl: string,
+  apiKey: string,
+  path: string,
+): Promise<{ status: number; body: unknown }> {
+  const url = `${normalizeBaseUrl(baseUrl)}${path}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'application/json',
+    },
+  });
+
+  let body: unknown;
+  const text = await response.text();
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = null;
+  }
+
+  return { status: response.status, body };
+}
+
+export function throwStructuredError(status: number, body: unknown): never {
+  const err = (body ?? {}) as ApiErrorBody;
+  throw new TurnurApiError(
+    status,
+    err.message ?? `Request failed with status ${status}`,
+    err.code,
+    err.hint,
+  );
+}
+
 export function throwUnauthorized(body: unknown): never {
   const err = (body ?? {}) as ApiErrorBody;
   throw new TurnurApiError(

--- a/packages/turnur-sdk/src/index.ts
+++ b/packages/turnur-sdk/src/index.ts
@@ -1,4 +1,10 @@
 export { createTurnurClient } from './client.js';
 export type { TurnurClient } from './client.js';
 export { TurnurApiError } from './errors.js';
-export type { ApiErrorBody, GameMeResponse, TurnurClientConfig } from './types.js';
+export type {
+  ApiErrorBody,
+  GameMeResponse,
+  MatchCreateResponse,
+  MatchGetResponse,
+  TurnurClientConfig,
+} from './types.js';

--- a/packages/turnur-sdk/src/types.ts
+++ b/packages/turnur-sdk/src/types.ts
@@ -7,6 +7,16 @@ export type GameMeResponse = {
   gameId: string;
 };
 
+export type MatchCreateResponse = {
+  matchId: string;
+};
+
+export type MatchGetResponse = {
+  matchId: string;
+  status: string;
+  createdAt: string;
+};
+
 export type ApiErrorBody = {
   code?: string;
   message?: string;


### PR DESCRIPTION
## Summary
- Add `client.match.create()` (`POST /v1/matches`, 201 → `{ matchId }`) and `client.match.get(matchId)` (`GET /v1/matches/{matchId}`, 200 → `{ matchId, status, createdAt }`)
- Add `authenticatedPost` HTTP helper and shared structured error handling for 401/403/404 via `TurnurApiError`
- Extend Vitest coverage with mocked fetch for Bearer auth, success parsing, and error codes

Closes #22

## Test plan
- [x] `npm run build && npm test` exit 0 from `packages/turnur-sdk/`
- [x] Tests assert Bearer header on create/get; 201/200 body parsing; 401/403/404 throw `TurnurApiError` with `code` and `message`
- [x] Grep `packages/turnur-sdk/src/`: no logging of `apiKey` or Authorization value
- [ ] CI passes on PR