### PR TITLE
Add POST and GET /v1/matches/:matchId/seats routes

### DIFF
--- a/infra/cdk/lambda/matches-seats-handler.test.ts
+++ b/infra/cdk/lambda/matches-seats-handler.test.ts
@@ -1,0 +1,419 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEV_FIXTURE_GAME_ID } from '../lib/game-auth/constants';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../test-fixtures/dev-game-key';
+import { handler } from './matches-seats-handler';
+
+const GAME_TABLE_NAME = 'GameRegistryTest';
+const MATCH_TABLE_NAME = 'MatchRegistryTest';
+const STATE_TABLE_NAME = 'MatchStateTest';
+const MATCH_ID = 'aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee';
+const MATCH_ID_B = 'bbbbbbbb-bbbb-4ccc-dddd-eeeeeeeeeeee';
+const OTHER_GAME_ID = 'game_other_00000000000000000000000000000000';
+const SEAT_ID_CLIENT = 'cccccccc-cccc-4ccc-dddd-eeeeeeeeeeee';
+
+function eventWithAuth(
+  method: 'GET' | 'POST',
+  value: string | undefined,
+  matchId: string = MATCH_ID,
+  body?: string,
+): APIGatewayProxyEventV2 {
+  const headers = value === undefined ? {} : { authorization: value };
+  return {
+    routeKey: `${method} /v1/matches/{matchId}/seats`,
+    headers,
+    pathParameters: { matchId },
+    body,
+    requestContext: {
+      http: { method },
+    },
+  } as APIGatewayProxyEventV2;
+}
+
+function responseBody(result: APIGatewayProxyResultV2): Record<string, unknown> {
+  if (typeof result === 'string' || !result.body) {
+    throw new Error('expected structured response');
+  }
+  return JSON.parse(result.body);
+}
+
+function statusCode(result: APIGatewayProxyResultV2): number {
+  if (typeof result === 'string') {
+    throw new Error('expected structured response');
+  }
+  return result.statusCode ?? 0;
+}
+
+function mockAuthAndOwnership(gameId: string = DEV_FIXTURE_GAME_ID, matchId: string = MATCH_ID) {
+  return [
+    { Item: { gameId: DEV_FIXTURE_GAME_ID } },
+    {
+      Item: {
+        matchId,
+        gameId,
+        status: 'created',
+        createdAt: '2026-08-27T12:00:00.000Z',
+      },
+    },
+  ];
+}
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('matches-seats-handler', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+    process.env.GAME_REGISTRY_TABLE_NAME = GAME_TABLE_NAME;
+    process.env.MATCH_REGISTRY_TABLE_NAME = MATCH_TABLE_NAME;
+    process.env.MATCH_STATE_TABLE_NAME = STATE_TABLE_NAME;
+    vi.spyOn(DynamoDBDocumentClient, 'from').mockReturnValue({
+      send,
+    } as unknown as DynamoDBDocumentClient);
+  });
+
+  it('POST returns 201 with server UUID seatId and currentSeat null', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth('POST', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    const body = responseBody(result!);
+    expect(Object.keys(body)).toEqual(['seatId', 'currentSeat']);
+    expect(body.currentSeat).toBeNull();
+    expect(body.seatId).toMatch(UUID_V4_PATTERN);
+    expect(body.seatId).not.toBe(SEAT_ID_CLIENT);
+
+    const putCalls = send.mock.calls.filter(([cmd]) => cmd instanceof PutCommand);
+    expect(putCalls).toHaveLength(2);
+    const seatPut = putCalls[0][0].input;
+    expect(seatPut.Item).toEqual(
+      expect.objectContaining({
+        matchId: MATCH_ID,
+        sk: `SEAT#${body.seatId}`,
+        seatId: body.seatId,
+      }),
+    );
+    expect(seatPut.Item).not.toHaveProperty('playerId');
+    expect(seatPut.Item).not.toHaveProperty('userId');
+
+    const cursorPut = putCalls[1][0].input;
+    expect(cursorPut.Item).toEqual(
+      expect.objectContaining({
+        matchId: MATCH_ID,
+        sk: 'CURSOR',
+        currentSeat: null,
+        seatOrder: [body.seatId],
+      }),
+    );
+  });
+
+  it('POST ignores client-supplied seatId and player identity in body', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        'POST',
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({
+          seatId: SEAT_ID_CLIENT,
+          playerId: 'player-1',
+          userId: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          sub: 'auth0|123',
+        }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    const body = responseBody(result!);
+    expect(body.seatId).not.toBe(SEAT_ID_CLIENT);
+
+    const seatPut = send.mock.calls.find(([cmd]) => cmd instanceof PutCommand)?.[0].input;
+    expect(seatPut?.Item).not.toHaveProperty('playerId');
+    expect(seatPut?.Item).not.toHaveProperty('userId');
+    expect(seatPut?.Item).not.toHaveProperty('name');
+    expect(seatPut?.Item).not.toHaveProperty('email');
+    expect(seatPut?.Item).not.toHaveProperty('sub');
+  });
+
+  it('two POSTs return distinct seatIds; GET lists both in creation order', async () => {
+    const createdAt1 = '2026-08-27T12:00:01.000Z';
+    const createdAt2 = '2026-08-27T12:00:02.000Z';
+    const storedSeatIds: string[] = [];
+
+    send.mockImplementation(async (cmd) => {
+      if (cmd instanceof GetCommand) {
+        const key = cmd.input.Key;
+        if (key?.keyHash !== undefined) {
+          return { Item: { gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.matchId === MATCH_ID && key?.sk === undefined) {
+          return { Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.sk === 'CURSOR') {
+          if (storedSeatIds.length === 0) {
+            return { Item: undefined };
+          }
+          return {
+            Item: {
+              matchId: MATCH_ID,
+              sk: 'CURSOR',
+              currentSeat: null,
+              seatOrder: [...storedSeatIds],
+            },
+          };
+        }
+        const seatIndex = storedSeatIds.findIndex((id) => key?.sk === `SEAT#${id}`);
+        if (seatIndex >= 0) {
+          const seatId = storedSeatIds[seatIndex];
+          return {
+            Item: {
+              matchId: MATCH_ID,
+              sk: `SEAT#${seatId}`,
+              seatId,
+              createdAt: seatIndex === 0 ? createdAt1 : createdAt2,
+            },
+          };
+        }
+      }
+      if (cmd instanceof PutCommand) {
+        const item = cmd.input.Item as { sk?: string; seatId?: string };
+        if (item.sk?.startsWith('SEAT#') && item.seatId) {
+          storedSeatIds.push(String(item.seatId));
+        }
+      }
+      return {};
+    });
+
+    const post1 = await handler(
+      eventWithAuth('POST', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+    const post2 = await handler(
+      eventWithAuth('POST', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    const firstSeatId = String(responseBody(post1!).seatId);
+    const secondSeatId = String(responseBody(post2!).seatId);
+    expect(firstSeatId).toMatch(UUID_V4_PATTERN);
+    expect(secondSeatId).toMatch(UUID_V4_PATTERN);
+    expect(firstSeatId).not.toBe(secondSeatId);
+    expect(responseBody(post1!).currentSeat).toBeNull();
+    expect(responseBody(post2!).currentSeat).toBeNull();
+
+    const list = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(list!)).toBe(200);
+    const listBody = responseBody(list!);
+    expect(Object.keys(listBody)).toEqual(['seats', 'currentSeat']);
+    expect(listBody.currentSeat).toBeNull();
+    expect(listBody.seats).toEqual([
+      { seatId: firstSeatId, createdAt: createdAt1 },
+      { seatId: secondSeatId, createdAt: createdAt2 },
+    ]);
+    expect(JSON.stringify(listBody)).not.toMatch(/view|hiddenView|playerId|userId/);
+  });
+
+  it('GET before any seat returns empty roster and currentSeat null', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    expect(responseBody(result!)).toEqual({ seats: [], currentSeat: null });
+  });
+
+  it('GET omits hidden-view fields even when VIEW# items exist', async () => {
+    const seatId = '33333333-3333-4333-8333-333333333333';
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: 'CURSOR',
+          currentSeat: null,
+          seatOrder: [seatId],
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: `SEAT#${seatId}`,
+          seatId,
+          createdAt: '2026-08-27T12:00:00.000Z',
+        },
+      });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    const body = responseBody(result!);
+    expect(body).toEqual({
+      seats: [{ seatId, createdAt: '2026-08-27T12:00:00.000Z' }],
+      currentSeat: null,
+    });
+    expect(body).not.toHaveProperty('view');
+    expect(body).not.toHaveProperty('views');
+    expect(body).not.toHaveProperty('hiddenView');
+    expect(body.seats[0]).not.toHaveProperty('view');
+
+    const getCalls = send.mock.calls.filter(([cmd]) => cmd instanceof GetCommand);
+    for (const [cmd] of getCalls) {
+      const key = cmd.input.Key;
+      expect(key?.sk ?? '').not.toMatch(/^VIEW#/);
+    }
+  });
+
+  it('returns 401 game_auth_required when Authorization is absent', async () => {
+    const result = await handler(eventWithAuth('POST', undefined), {} as never, () => {});
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_required' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 game_auth_invalid for an unknown SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('POST', 'Bearer turnur_sk_11111111111111111111111111111111'),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it('returns 404 match_not_found when match item is absent', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('POST', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(404);
+    expect(responseBody(result!)).toMatchObject({ code: 'match_not_found' });
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+  });
+
+  it('returns 403 match_forbidden when match belongs to another game', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          gameId: OTHER_GAME_ID,
+          status: 'created',
+          createdAt: '2026-08-27T12:00:00.000Z',
+        },
+      });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(403);
+    const body = responseBody(result!);
+    expect(body).toMatchObject({ code: 'match_forbidden' });
+    expect(body).not.toHaveProperty('matchId');
+    expect(body).not.toHaveProperty('seats');
+    expect(body).not.toHaveProperty('currentSeat');
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls.some(([cmd]) => cmd.input?.Key?.sk === 'CURSOR')).toBe(false);
+  });
+
+  it('seats on match A do not appear on GET for match B', async () => {
+    const seatIdA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    send.mockImplementation(async (cmd) => {
+      if (cmd instanceof GetCommand) {
+        const key = cmd.input.Key;
+        if (key?.keyHash !== undefined) {
+          return { Item: { gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.matchId === MATCH_ID_B && key?.sk === undefined) {
+          return { Item: { matchId: MATCH_ID_B, gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.matchId === MATCH_ID_B && key?.sk === 'CURSOR') {
+          return { Item: undefined };
+        }
+        if (key?.matchId === MATCH_ID && key?.sk === `SEAT#${seatIdA}`) {
+          throw new Error('should not query match A seats from match B GET');
+        }
+      }
+      return {};
+    });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`, MATCH_ID_B),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    expect(responseBody(result!)).toEqual({ seats: [], currentSeat: null });
+  });
+});

--- a/infra/cdk/lambda/matches-seats-handler.ts
+++ b/infra/cdk/lambda/matches-seats-handler.ts
@@ -1,0 +1,227 @@
+/**
+ * POST /v1/matches/{matchId}/seats — create a seat (server-issued seatId).
+ * GET /v1/matches/{matchId}/seats — list public roster + currentSeat.
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { randomUUID } from 'crypto';
+
+import { requireGameAuth } from '../lib/game-auth/require-game-auth';
+
+export type CreateSeatResponseBody = {
+  seatId: string;
+  currentSeat: null;
+};
+
+export type SeatRosterEntry = {
+  seatId: string;
+  createdAt: string;
+};
+
+export type ListSeatsResponseBody = {
+  seats: SeatRosterEntry[];
+  currentSeat: string | null;
+};
+
+type MatchErrorCode = 'match_not_found' | 'match_forbidden';
+
+type MatchErrorBody = {
+  code: MatchErrorCode;
+  message: string;
+  hint: string;
+};
+
+type CursorItem = {
+  currentSeat?: string | null;
+  seatOrder?: string[];
+};
+
+function jsonResponse(statusCode: number, body: unknown): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+}
+
+function matchErrorResponse(
+  statusCode: number,
+  body: MatchErrorBody,
+): APIGatewayProxyResultV2 {
+  return jsonResponse(statusCode, body);
+}
+
+function buildMatchNotFoundResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(404, {
+    code: 'match_not_found',
+    message: 'Match not found',
+    hint: 'Verify the matchId exists and was created via POST /v1/matches for your game.',
+  });
+}
+
+function buildMatchForbiddenResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(403, {
+    code: 'match_forbidden',
+    message: 'Match belongs to another game',
+    hint: 'Use the SDK key for the game that created this match.',
+  });
+}
+
+async function assertMatchOwnership(
+  docClient: DynamoDBDocumentClient,
+  matchRegistryTable: string,
+  matchId: string,
+  gameId: string,
+): Promise<APIGatewayProxyResultV2 | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: matchRegistryTable,
+      Key: { matchId },
+    }),
+  );
+
+  if (!result.Item) {
+    return buildMatchNotFoundResponse();
+  }
+
+  if (result.Item.gameId !== gameId) {
+    return buildMatchForbiddenResponse();
+  }
+
+  return null;
+}
+
+async function handlePostSeats(
+  docClient: DynamoDBDocumentClient,
+  matchStateTable: string,
+  matchId: string,
+): Promise<APIGatewayProxyResultV2> {
+  const seatId = randomUUID();
+  const createdAt = new Date().toISOString();
+
+  const cursorResult = await docClient.send(
+    new GetCommand({
+      TableName: matchStateTable,
+      Key: { matchId, sk: 'CURSOR' },
+    }),
+  );
+
+  const existing = (cursorResult.Item ?? {}) as CursorItem;
+  const currentSeat = existing.currentSeat ?? null;
+  const seatOrder = [...(existing.seatOrder ?? []), seatId];
+
+  await docClient.send(
+    new PutCommand({
+      TableName: matchStateTable,
+      Item: {
+        matchId,
+        sk: `SEAT#${seatId}`,
+        seatId,
+        createdAt,
+      },
+    }),
+  );
+
+  await docClient.send(
+    new PutCommand({
+      TableName: matchStateTable,
+      Item: {
+        matchId,
+        sk: 'CURSOR',
+        currentSeat,
+        seatOrder,
+      },
+    }),
+  );
+
+  const body: CreateSeatResponseBody = { seatId, currentSeat: null };
+  return jsonResponse(201, body);
+}
+
+async function handleGetSeats(
+  docClient: DynamoDBDocumentClient,
+  matchStateTable: string,
+  matchId: string,
+): Promise<APIGatewayProxyResultV2> {
+  const cursorResult = await docClient.send(
+    new GetCommand({
+      TableName: matchStateTable,
+      Key: { matchId, sk: 'CURSOR' },
+    }),
+  );
+
+  if (!cursorResult.Item) {
+    const body: ListSeatsResponseBody = { seats: [], currentSeat: null };
+    return jsonResponse(200, body);
+  }
+
+  const cursor = cursorResult.Item as CursorItem;
+  const currentSeat = cursor.currentSeat ?? null;
+  const seatOrder = cursor.seatOrder ?? [];
+  const seats: SeatRosterEntry[] = [];
+
+  for (const id of seatOrder) {
+    const seatResult = await docClient.send(
+      new GetCommand({
+        TableName: matchStateTable,
+        Key: { matchId, sk: `SEAT#${id}` },
+      }),
+    );
+
+    if (seatResult.Item?.seatId && seatResult.Item?.createdAt) {
+      seats.push({
+        seatId: String(seatResult.Item.seatId),
+        createdAt: String(seatResult.Item.createdAt),
+      });
+    }
+  }
+
+  const body: ListSeatsResponseBody = { seats, currentSeat };
+  return jsonResponse(200, body);
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const auth = await requireGameAuth(event);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const matchId = event.pathParameters?.matchId;
+  if (!matchId) {
+    return buildMatchNotFoundResponse();
+  }
+
+  const matchRegistryTable = process.env.MATCH_REGISTRY_TABLE_NAME;
+  const matchStateTable = process.env.MATCH_STATE_TABLE_NAME;
+  if (!matchRegistryTable) {
+    throw new Error('MATCH_REGISTRY_TABLE_NAME is not configured');
+  }
+  if (!matchStateTable) {
+    throw new Error('MATCH_STATE_TABLE_NAME is not configured');
+  }
+
+  const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+  const ownershipError = await assertMatchOwnership(
+    docClient,
+    matchRegistryTable,
+    matchId,
+    auth.context.gameId,
+  );
+  if (ownershipError) {
+    return ownershipError;
+  }
+
+  const method = event.requestContext.http.method;
+
+  if (method === 'POST') {
+    return handlePostSeats(docClient, matchStateTable, matchId);
+  }
+
+  if (method === 'GET') {
+    return handleGetSeats(docClient, matchStateTable, matchId);
+  }
+
+  return jsonResponse(405, { message: 'Method Not Allowed' });
+};

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -94,6 +94,44 @@ function policyStatements(template: Template): Array<{
   );
 }
 
+function lambdaPolicyStatements(
+  template: Template,
+  logicalIdFragment: string,
+): Array<{ Action?: string | string[]; Resource?: string | string[] }> {
+  const functions = template.findResources('AWS::Lambda::Function');
+  const fnEntry = Object.entries(functions).find(([id]) => id.includes(logicalIdFragment));
+  if (!fnEntry) {
+    return [];
+  }
+
+  const roleRef = fnEntry[1].Properties?.Role as
+    | { 'Fn::GetAtt'?: [string, string] }
+    | { Ref?: string }
+    | undefined;
+  const roleLogicalId =
+    roleRef && 'Fn::GetAtt' in roleRef
+      ? roleRef['Fn::GetAtt']?.[0]
+      : roleRef && 'Ref' in roleRef
+        ? roleRef.Ref
+        : undefined;
+
+  if (!roleLogicalId) {
+    return [];
+  }
+
+  const policies = template.findResources('AWS::IAM::Policy');
+  return Object.values(policies).flatMap((policy) => {
+    const roles = policy.Properties?.Roles ?? [];
+    const attached = roles.some(
+      (role: { Ref?: string }) => role.Ref === roleLogicalId,
+    );
+    if (!attached) {
+      return [];
+    }
+    return policy.Properties?.PolicyDocument?.Statement ?? [];
+  });
+}
+
 function hasActionOnTableResource(
   statements: Array<{ Action?: string | string[]; Resource?: string | string[] }>,
   action: string,
@@ -137,7 +175,7 @@ describe('TurnurApiStack', () => {
       Runtime: 'nodejs22.x',
     });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Route', 4);
+    template.resourceCountIs('AWS::ApiGatewayV2::Route', 6);
     template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
       RouteKey: 'GET /v1/health',
       AuthorizationType: 'NONE',
@@ -154,8 +192,16 @@ describe('TurnurApiStack', () => {
       RouteKey: 'GET /v1/matches/{matchId}',
       AuthorizationType: 'NONE',
     });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'POST /v1/matches/{matchId}/seats',
+      AuthorizationType: 'NONE',
+    });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'GET /v1/matches/{matchId}/seats',
+      AuthorizationType: 'NONE',
+    });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 4);
+    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 5);
     template.hasResourceProperties('AWS::ApiGatewayV2::Integration', {
       IntegrationType: 'AWS_PROXY',
       PayloadFormatVersion: '2.0',
@@ -347,27 +393,27 @@ describe('TurnurApiStack', () => {
     const app = new cdk.App();
     const stack = new TurnurApiStack(app, 'TurnurApiStackShippedHandlerIsolationTest');
     const template = Template.fromStack(stack);
-    const statements = policyStatements(template);
 
-    for (const fnId of ['GameMeFn', 'MatchesAttachFn', 'MatchesProbeFn']) {
+    for (const fnId of ['HealthFn', 'GameMeFn', 'MatchesAttachFn', 'MatchesProbeFn']) {
       const env = lambdaEnvVars(template, fnId);
       expect(env).not.toHaveProperty('MATCH_STATE_TABLE_NAME');
       expect(env).not.toHaveProperty('MATCH_MOVE_LOG_TABLE_NAME');
-    }
 
-    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchState')).toBe(false);
-    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchState')).toBe(false);
-    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchState')).toBe(false);
-    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchMoveLog')).toBe(false);
-    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchMoveLog')).toBe(false);
-    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchMoveLog')).toBe(false);
+      const statements = lambdaPolicyStatements(template, fnId);
+      expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchState')).toBe(false);
+      expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchState')).toBe(false);
+      expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchState')).toBe(false);
+      expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchMoveLog')).toBe(false);
+      expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchMoveLog')).toBe(false);
+      expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchMoveLog')).toBe(false);
+    }
   });
 
   it('protected Lambda factory with matchStateRead grants GetItem and sets env var', () => {
     const app = new cdk.App();
     const stack = new MatchStateReadProbeStack(app, 'TurnurApiStackMatchStateReadTest');
     const template = Template.fromStack(stack);
-    const statements = policyStatements(template);
+    const statements = lambdaPolicyStatements(template, 'MatchStateReadProbeFn');
 
     template.hasResourceProperties('AWS::Lambda::Function', {
       Runtime: 'nodejs22.x',
@@ -387,7 +433,7 @@ describe('TurnurApiStack', () => {
     const app = new cdk.App();
     const stack = new MatchStateWriteProbeStack(app, 'TurnurApiStackMatchStateWriteTest');
     const template = Template.fromStack(stack);
-    const statements = policyStatements(template);
+    const statements = lambdaPolicyStatements(template, 'MatchStateWriteProbeFn');
 
     template.hasResourceProperties('AWS::Lambda::Function', {
       Runtime: 'nodejs22.x',
@@ -441,5 +487,28 @@ describe('TurnurApiStack', () => {
     expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchMoveLog')).toBe(true);
     expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchMoveLog')).toBe(false);
     expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchMoveLog')).toBe(false);
+  });
+
+  it('MatchesSeatsFn receives MatchState and MatchRegistry env and IAM without MatchMoveLog or Query', () => {
+    const app = new cdk.App();
+    const stack = new TurnurApiStack(app, 'TurnurApiStackMatchesSeatsTest');
+    const template = Template.fromStack(stack);
+    const statements = lambdaPolicyStatements(template, 'MatchesSeatsFn');
+
+    const env = lambdaEnvVars(template, 'MatchesSeatsFn');
+    expect(env).toMatchObject({
+      GAME_REGISTRY_TABLE_NAME: expect.anything(),
+      MATCH_REGISTRY_TABLE_NAME: expect.anything(),
+      MATCH_STATE_TABLE_NAME: expect.anything(),
+    });
+    expect(env).not.toHaveProperty('MATCH_MOVE_LOG_TABLE_NAME');
+
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchRegistry')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchState')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchState')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchState')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchMoveLog')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchMoveLog')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchMoveLog')).toBe(false);
   });
 });

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -26,6 +26,7 @@ export class TurnurApiStack extends cdk.Stack {
   public readonly gameMeFunction: lambdaNodejs.NodejsFunction;
   public readonly matchesAttachFunction: lambdaNodejs.NodejsFunction;
   public readonly matchesProbeFunction: lambdaNodejs.NodejsFunction;
+  public readonly matchesSeatsFunction: lambdaNodejs.NodejsFunction;
   public readonly gameRegistryTable: dynamodb.Table;
   public readonly matchRegistryTable: dynamodb.Table;
   public readonly matchStateTable: dynamodb.Table;
@@ -192,6 +193,26 @@ export class TurnurApiStack extends cdk.Stack {
       path: '/v1/matches/{matchId}',
       methods: [apigwv2.HttpMethod.GET],
       integration: matchesProbeIntegration,
+    });
+
+    this.matchesSeatsFunction = this.createProtectedNodejsFunction('MatchesSeatsFn', {
+      entry: path.join(__dirname, '../lambda/matches-seats-handler.ts'),
+      handler: 'handler',
+      description: 'POST/GET /v1/matches/{matchId}/seats — create and list seats',
+      matchRegistryRead: true,
+      matchStateRead: true,
+      matchStateWrite: true,
+    });
+
+    const matchesSeatsIntegration = new integrations.HttpLambdaIntegration(
+      'MatchesSeatsInt',
+      this.matchesSeatsFunction,
+    );
+
+    this.httpApi.addRoutes({
+      path: '/v1/matches/{matchId}/seats',
+      methods: [apigwv2.HttpMethod.POST, apigwv2.HttpMethod.GET],
+      integration: matchesSeatsIntegration,
     });
   }
 


### PR DESCRIPTION
## Summary

- Add `matches-seats-handler` Lambda serving `POST` and `GET /v1/matches/{matchId}/seats` with game SDK key auth and match ownership checks (same 401/403/404 envelopes as match probe).
- `POST` issues a server UUID v4 `seatId`, writes `SEAT#{seatId}` and updates `CURSOR.seatOrder` in MatchState; `currentSeat` stays null.
- `GET` lists the roster via `CURSOR.seatOrder` + per-seat GetItem (no Query, no hidden views).

Closes #30

## Test plan

- [x] `cd infra/cdk && npm test` exits 0
- [x] `cd infra/cdk && npm run synth` exits 0
- [x] Handler tests cover auth, ownership, create, list, hidden-view omission, and cross-match isolation
- [x] CDK tests assert route count 6 and MatchesSeatsFn IAM (MatchRegistry GetItem + MatchState GetItem/PutItem only)