### PR TITLE
Add GET/PUT /v1/matches/:matchId/turn and POST /moves routes (#31)

### DIFF
--- a/infra/cdk/lambda/matches-moves-handler.test.ts
+++ b/infra/cdk/lambda/matches-moves-handler.test.ts
@@ -1,0 +1,554 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEV_FIXTURE_GAME_ID } from '../lib/game-auth/constants';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../test-fixtures/dev-game-key';
+import { handler } from './matches-moves-handler';
+
+const GAME_TABLE_NAME = 'GameRegistryTest';
+const MATCH_TABLE_NAME = 'MatchRegistryTest';
+const STATE_TABLE_NAME = 'MatchStateTest';
+const MOVE_LOG_TABLE_NAME = 'MatchMoveLogTest';
+const MATCH_ID = 'aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee';
+const MATCH_ID_B = 'bbbbbbbb-bbbb-4ccc-dddd-eeeeeeeeeeee';
+const OTHER_GAME_ID = 'game_other_00000000000000000000000000000000';
+const SEAT_ID_1 = '11111111-1111-4111-8111-111111111111';
+const SEAT_ID_2 = '22222222-2222-4222-8222-222222222222';
+const SEAT_ID_OTHER = '33333333-3333-4333-8333-333333333333';
+
+function eventWithAuth(
+  value: string | undefined,
+  matchId: string = MATCH_ID,
+  body?: string,
+): APIGatewayProxyEventV2 {
+  const headers = value === undefined ? {} : { authorization: value };
+  return {
+    routeKey: 'POST /v1/matches/{matchId}/moves',
+    headers,
+    pathParameters: { matchId },
+    body,
+    requestContext: {
+      http: { method: 'POST' },
+    },
+  } as APIGatewayProxyEventV2;
+}
+
+function responseBody(result: APIGatewayProxyResultV2): Record<string, unknown> {
+  if (typeof result === 'string' || !result.body) {
+    throw new Error('expected structured response');
+  }
+  return JSON.parse(result.body);
+}
+
+function statusCode(result: APIGatewayProxyResultV2): number {
+  if (typeof result === 'string') {
+    throw new Error('expected structured response');
+  }
+  return result.statusCode ?? 0;
+}
+
+describe('matches-moves-handler', () => {
+  const send = vi.fn();
+
+  function mockAuthAndOwnershipCalls(matchId: string = MATCH_ID): void {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId, gameId: DEV_FIXTURE_GAME_ID },
+      });
+  }
+
+  beforeEach(() => {
+    send.mockReset();
+    process.env.GAME_REGISTRY_TABLE_NAME = GAME_TABLE_NAME;
+    process.env.MATCH_REGISTRY_TABLE_NAME = MATCH_TABLE_NAME;
+    process.env.MATCH_STATE_TABLE_NAME = STATE_TABLE_NAME;
+    process.env.MATCH_MOVE_LOG_TABLE_NAME = MOVE_LOG_TABLE_NAME;
+    vi.spyOn(DynamoDBDocumentClient, 'from').mockReturnValue({
+      send,
+    } as unknown as DynamoDBDocumentClient);
+  });
+
+  it('POST on-turn move returns 201 with seq 1 and unchanged currentSeat', async () => {
+    const payload = { action: 'would-be-illegal-under-game-rules', value: 99 };
+
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: `SEAT#${SEAT_ID_1}`,
+          seatId: SEAT_ID_1,
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: 'CURSOR',
+          currentSeat: SEAT_ID_1,
+          seatOrder: [SEAT_ID_1, SEAT_ID_2],
+        },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    const body = responseBody(result!);
+    expect(Object.keys(body)).toEqual(['seq', 'seatId', 'createdAt', 'currentSeat']);
+    expect(body.seq).toBe(1);
+    expect(typeof body.seq).toBe('number');
+    expect(body.seatId).toBe(SEAT_ID_1);
+    expect(body.currentSeat).toBe(SEAT_ID_1);
+    expect(body).not.toHaveProperty('payload');
+
+    const putCall = send.mock.calls.find(([cmd]) => cmd instanceof PutCommand);
+    expect(putCall).toBeDefined();
+    expect(putCall![0].input.Item).toMatchObject({
+      matchId: MATCH_ID,
+      seq: 1,
+      seatId: SEAT_ID_1,
+      payload,
+    });
+    expect(putCall![0].input.ConditionExpression).toBe('attribute_not_exists(seq)');
+  });
+
+  it('accepts payload {} when on-turn', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: {} }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    const putCall = send.mock.calls.find(([cmd]) => cmd instanceof PutCommand);
+    expect(putCall![0].input.Item?.payload).toEqual({});
+  });
+
+  it('second on-turn POST without intervening PUT returns seq 2', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({ Items: [{ seq: 1, seatId: SEAT_ID_1 }] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { turn: 2 } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    const body = responseBody(result!);
+    expect(body.seq).toBe(2);
+    expect(body.currentSeat).toBe(SEAT_ID_1);
+  });
+
+  it('off-turn POST returns 409 illegal_turn without MoveLog PutItem', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_2}`, seatId: SEAT_ID_2 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      });
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_2, payload: { action: 'off-turn' } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(409);
+    expect(responseBody(result!)).toMatchObject({ code: 'illegal_turn' });
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof QueryCommand)).toBe(false);
+  });
+
+  it('following on-turn POST after rejected off-turn uses next unused seq', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({ Items: [{ seq: 1 }] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { action: 'valid' } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    expect(responseBody(result!).seq).toBe(2);
+  });
+
+  it('POST without designate returns 409 illegal_turn', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: null },
+      });
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { action: 'early' } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(409);
+    expect(responseBody(result!)).toMatchObject({ code: 'illegal_turn' });
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+  });
+
+  it('ConditionalCheckFailedException returns 409 illegal_turn', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockRejectedValueOnce(new ConditionalCheckFailedException({ message: 'race', $metadata: {} }));
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { action: 'race' } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(409);
+    expect(responseBody(result!)).toMatchObject({ code: 'illegal_turn' });
+  });
+
+  it('POST with invalid body fields returns 400 invalid_request', async () => {
+    const invalidBodies = [
+      undefined,
+      JSON.stringify({ payload: { x: 1 } }),
+      JSON.stringify({ seatId: SEAT_ID_1 }),
+      JSON.stringify({ seatId: SEAT_ID_1, payload: null }),
+      JSON.stringify({ seatId: '', payload: { x: 1 } }),
+      JSON.stringify({ seatId: 123, payload: { x: 1 } }),
+    ];
+
+    for (const body of invalidBodies) {
+      send.mockReset();
+      vi.spyOn(DynamoDBDocumentClient, 'from').mockReturnValue({
+        send,
+      } as unknown as DynamoDBDocumentClient);
+      mockAuthAndOwnershipCalls();
+
+      const result = await handler(
+        eventWithAuth(`Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`, MATCH_ID, body),
+        {} as never,
+        () => {},
+      );
+
+      expect(statusCode(result!)).toBe(400);
+      expect(responseBody(result!)).toMatchObject({ code: 'invalid_request' });
+      expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+    }
+  });
+
+  it('POST for unknown seat returns 404 seat_not_found even when currentSeat is null', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_OTHER, payload: { x: 1 } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(404);
+    expect(responseBody(result!)).toMatchObject({ code: 'seat_not_found' });
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+  });
+
+  it('POST 201 keys omit view and payload echo', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { secret: 'view-data' } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    const body = responseBody(result!);
+    expect(Object.keys(body)).toEqual(['seq', 'seatId', 'createdAt', 'currentSeat']);
+    expect(body).not.toHaveProperty('payload');
+    expect(body).not.toHaveProperty('view');
+  });
+
+  it('does not PutItem MatchState on accept', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { x: 1 } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    const putCalls = send.mock.calls.filter(([cmd]) => cmd instanceof PutCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0][0].input.TableName).toBe(MOVE_LOG_TABLE_NAME);
+  });
+
+  it('returns 401 game_auth_required when Authorization is absent', async () => {
+    const result = await handler(eventWithAuth(undefined), {} as never, () => {});
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_required' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 game_auth_invalid for an unknown SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('Bearer turnur_sk_11111111111111111111111111111111'),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it('returns 404 match_not_found when match item is absent', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { x: 1 } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(404);
+    expect(responseBody(result!)).toMatchObject({ code: 'match_not_found' });
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+  });
+
+  it('returns 403 match_forbidden when match belongs to another game', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          gameId: OTHER_GAME_ID,
+          status: 'created',
+          createdAt: '2026-08-27T12:00:00.000Z',
+        },
+      });
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { x: 1 } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(403);
+    const body = responseBody(result!);
+    expect(body).toMatchObject({ code: 'match_forbidden' });
+    expect(body).not.toHaveProperty('matchId');
+    expect(body).not.toHaveProperty('seq');
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+  });
+
+  it('moves on match B do not use match A seatId', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID_B, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID_B,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { x: 1 } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(404);
+    expect(responseBody(result!)).toMatchObject({ code: 'seat_not_found' });
+  });
+
+  it('first on-turn accept on match B returns seq 1', async () => {
+    const seatB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID_B, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID_B, sk: `SEAT#${seatB}`, seatId: seatB },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID_B, sk: 'CURSOR', currentSeat: seatB },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID_B,
+        JSON.stringify({ seatId: seatB, payload: { first: true } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    expect(responseBody(result!).seq).toBe(1);
+    const putCall = send.mock.calls.find(([cmd]) => cmd instanceof PutCommand);
+    expect(putCall![0].input.Item?.matchId).toBe(MATCH_ID_B);
+  });
+
+  it('Query uses ScanIndexForward false and Limit 1', async () => {
+    mockAuthAndOwnershipCalls();
+    send
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: `SEAT#${SEAT_ID_1}`, seatId: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, sk: 'CURSOR', currentSeat: SEAT_ID_1 },
+      })
+      .mockResolvedValueOnce({ Items: [{ seq: 5 }] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      eventWithAuth(
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1, payload: { x: 1 } }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(201);
+    expect(responseBody(result!).seq).toBe(6);
+
+    const queryCall = send.mock.calls.find(([cmd]) => cmd instanceof QueryCommand);
+    expect(queryCall).toBeDefined();
+    expect(queryCall![0].input.ScanIndexForward).toBe(false);
+    expect(queryCall![0].input.Limit).toBe(1);
+  });
+});

--- a/infra/cdk/lambda/matches-moves-handler.ts
+++ b/infra/cdk/lambda/matches-moves-handler.ts
@@ -1,0 +1,298 @@
+/**
+ * POST /v1/matches/{matchId}/moves — append an on-turn move to the move log.
+ */
+import {
+  ConditionalCheckFailedException,
+  DynamoDBClient,
+} from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+
+import { requireGameAuth } from '../lib/game-auth/require-game-auth';
+
+export type MoveCreateResponseBody = {
+  seq: number;
+  seatId: string;
+  createdAt: string;
+  currentSeat: string;
+};
+
+type MatchErrorCode = 'match_not_found' | 'match_forbidden';
+
+type MatchErrorBody = {
+  code: MatchErrorCode;
+  message: string;
+  hint: string;
+};
+
+type InvalidRequestBody = {
+  code: 'invalid_request';
+  message: string;
+  hint: string;
+};
+
+type SeatNotFoundBody = {
+  code: 'seat_not_found';
+  message: string;
+  hint: string;
+};
+
+type IllegalTurnBody = {
+  code: 'illegal_turn';
+  message: string;
+  hint: string;
+};
+
+type CursorItem = {
+  currentSeat?: string | null;
+};
+
+type ParsedMoveBody =
+  | { ok: false; response: APIGatewayProxyResultV2 }
+  | { ok: true; seatId: string; payload: unknown };
+
+function jsonResponse(statusCode: number, body: unknown): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+}
+
+function matchErrorResponse(
+  statusCode: number,
+  body: MatchErrorBody,
+): APIGatewayProxyResultV2 {
+  return jsonResponse(statusCode, body);
+}
+
+function buildMatchNotFoundResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(404, {
+    code: 'match_not_found',
+    message: 'Match not found',
+    hint: 'Verify the matchId exists and was created via POST /v1/matches for your game.',
+  });
+}
+
+function buildMatchForbiddenResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(403, {
+    code: 'match_forbidden',
+    message: 'Match belongs to another game',
+    hint: 'Use the SDK key for the game that created this match.',
+  });
+}
+
+function buildInvalidRequestResponse(): APIGatewayProxyResultV2 {
+  const body: InvalidRequestBody = {
+    code: 'invalid_request',
+    message: 'Invalid request',
+    hint: 'Provide seatId and payload in the request body.',
+  };
+  return jsonResponse(400, body);
+}
+
+function buildSeatNotFoundResponse(): APIGatewayProxyResultV2 {
+  const body: SeatNotFoundBody = {
+    code: 'seat_not_found',
+    message: 'Seat not found',
+    hint: 'Create the seat via POST /v1/matches/{matchId}/seats before designating it or submitting a move.',
+  };
+  return jsonResponse(404, body);
+}
+
+function buildIllegalTurnResponse(): APIGatewayProxyResultV2 {
+  const body: IllegalTurnBody = {
+    code: 'illegal_turn',
+    message: 'Illegal turn',
+    hint: 'Submit a move only for the current seat. Designate a seat with PUT /v1/matches/{matchId}/turn first if none is current.',
+  };
+  return jsonResponse(409, body);
+}
+
+function parseMoveBody(body: string | undefined): ParsedMoveBody {
+  if (body === undefined || body === '') {
+    return { ok: false, response: buildInvalidRequestResponse() };
+  }
+  try {
+    const parsed = JSON.parse(body) as { seatId?: unknown; payload?: unknown };
+    if (typeof parsed.seatId !== 'string') {
+      return { ok: false, response: buildInvalidRequestResponse() };
+    }
+    const trimmed = parsed.seatId.trim();
+    if (trimmed === '') {
+      return { ok: false, response: buildInvalidRequestResponse() };
+    }
+    if (!('payload' in parsed) || parsed.payload === null || parsed.payload === undefined) {
+      return { ok: false, response: buildInvalidRequestResponse() };
+    }
+    return { ok: true, seatId: trimmed, payload: parsed.payload };
+  } catch {
+    return { ok: false, response: buildInvalidRequestResponse() };
+  }
+}
+
+async function assertMatchOwnership(
+  docClient: DynamoDBDocumentClient,
+  matchRegistryTable: string,
+  matchId: string,
+  gameId: string,
+): Promise<APIGatewayProxyResultV2 | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: matchRegistryTable,
+      Key: { matchId },
+    }),
+  );
+
+  if (!result.Item) {
+    return buildMatchNotFoundResponse();
+  }
+
+  if (result.Item.gameId !== gameId) {
+    return buildMatchForbiddenResponse();
+  }
+
+  return null;
+}
+
+async function handlePostMove(
+  docClient: DynamoDBDocumentClient,
+  matchStateTable: string,
+  matchMoveLogTable: string,
+  matchId: string,
+  body: string | undefined,
+): Promise<APIGatewayProxyResultV2> {
+  const parsed = parseMoveBody(body);
+  if (!parsed.ok) {
+    return parsed.response;
+  }
+
+  const { seatId, payload } = parsed;
+
+  const seatResult = await docClient.send(
+    new GetCommand({
+      TableName: matchStateTable,
+      Key: { matchId, sk: `SEAT#${seatId}` },
+    }),
+  );
+
+  if (!seatResult.Item) {
+    return buildSeatNotFoundResponse();
+  }
+
+  const cursorResult = await docClient.send(
+    new GetCommand({
+      TableName: matchStateTable,
+      Key: { matchId, sk: 'CURSOR' },
+    }),
+  );
+
+  const cursor = (cursorResult.Item ?? {}) as CursorItem;
+  const currentSeat = cursor.currentSeat ?? null;
+
+  if (currentSeat === null || seatId !== currentSeat) {
+    return buildIllegalTurnResponse();
+  }
+
+  const lastSeqResult = await docClient.send(
+    new QueryCommand({
+      TableName: matchMoveLogTable,
+      KeyConditionExpression: 'matchId = :matchId',
+      ExpressionAttributeValues: { ':matchId': matchId },
+      ScanIndexForward: false,
+      Limit: 1,
+    }),
+  );
+
+  const lastSeq =
+    lastSeqResult.Items && lastSeqResult.Items.length > 0
+      ? Number(lastSeqResult.Items[0].seq)
+      : 0;
+  const nextSeq = lastSeq + 1;
+  const createdAt = new Date().toISOString();
+
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: matchMoveLogTable,
+        Item: {
+          matchId,
+          seq: nextSeq,
+          seatId,
+          payload,
+          createdAt,
+        },
+        ConditionExpression: 'attribute_not_exists(seq)',
+      }),
+    );
+  } catch (error) {
+    if (error instanceof ConditionalCheckFailedException) {
+      return buildIllegalTurnResponse();
+    }
+    throw error;
+  }
+
+  const responseBody: MoveCreateResponseBody = {
+    seq: nextSeq,
+    seatId,
+    createdAt,
+    currentSeat,
+  };
+  return jsonResponse(201, responseBody);
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const auth = await requireGameAuth(event);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const matchId = event.pathParameters?.matchId;
+  if (!matchId) {
+    return buildMatchNotFoundResponse();
+  }
+
+  const matchRegistryTable = process.env.MATCH_REGISTRY_TABLE_NAME;
+  const matchStateTable = process.env.MATCH_STATE_TABLE_NAME;
+  const matchMoveLogTable = process.env.MATCH_MOVE_LOG_TABLE_NAME;
+  if (!matchRegistryTable) {
+    throw new Error('MATCH_REGISTRY_TABLE_NAME is not configured');
+  }
+  if (!matchStateTable) {
+    throw new Error('MATCH_STATE_TABLE_NAME is not configured');
+  }
+  if (!matchMoveLogTable) {
+    throw new Error('MATCH_MOVE_LOG_TABLE_NAME is not configured');
+  }
+
+  const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+  const ownershipError = await assertMatchOwnership(
+    docClient,
+    matchRegistryTable,
+    matchId,
+    auth.context.gameId,
+  );
+  if (ownershipError) {
+    return ownershipError;
+  }
+
+  const method = event.requestContext.http.method;
+
+  if (method === 'POST') {
+    return handlePostMove(
+      docClient,
+      matchStateTable,
+      matchMoveLogTable,
+      matchId,
+      event.body,
+    );
+  }
+
+  return jsonResponse(405, { message: 'Method Not Allowed' });
+};

--- a/infra/cdk/lambda/matches-turn-handler.test.ts
+++ b/infra/cdk/lambda/matches-turn-handler.test.ts
@@ -1,0 +1,426 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEV_FIXTURE_GAME_ID } from '../lib/game-auth/constants';
+import { DEV_FIXTURE_PLAINTEXT_SDK_KEY } from '../test-fixtures/dev-game-key';
+import { handler } from './matches-turn-handler';
+
+const GAME_TABLE_NAME = 'GameRegistryTest';
+const MATCH_TABLE_NAME = 'MatchRegistryTest';
+const STATE_TABLE_NAME = 'MatchStateTest';
+const MATCH_ID = 'aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee';
+const MATCH_ID_B = 'bbbbbbbb-bbbb-4ccc-dddd-eeeeeeeeeeee';
+const OTHER_GAME_ID = 'game_other_00000000000000000000000000000000';
+const SEAT_ID_1 = '11111111-1111-4111-8111-111111111111';
+const SEAT_ID_2 = '22222222-2222-4222-8222-222222222222';
+const SEAT_ID_OTHER = '33333333-3333-4333-8333-333333333333';
+
+function eventWithAuth(
+  method: 'GET' | 'PUT',
+  value: string | undefined,
+  matchId: string = MATCH_ID,
+  body?: string,
+): APIGatewayProxyEventV2 {
+  const headers = value === undefined ? {} : { authorization: value };
+  return {
+    routeKey: `${method} /v1/matches/{matchId}/turn`,
+    headers,
+    pathParameters: { matchId },
+    body,
+    requestContext: {
+      http: { method },
+    },
+  } as APIGatewayProxyEventV2;
+}
+
+function responseBody(result: APIGatewayProxyResultV2): Record<string, unknown> {
+  if (typeof result === 'string' || !result.body) {
+    throw new Error('expected structured response');
+  }
+  return JSON.parse(result.body);
+}
+
+function statusCode(result: APIGatewayProxyResultV2): number {
+  if (typeof result === 'string') {
+    throw new Error('expected structured response');
+  }
+  return result.statusCode ?? 0;
+}
+
+describe('matches-turn-handler', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+    process.env.GAME_REGISTRY_TABLE_NAME = GAME_TABLE_NAME;
+    process.env.MATCH_REGISTRY_TABLE_NAME = MATCH_TABLE_NAME;
+    process.env.MATCH_STATE_TABLE_NAME = STATE_TABLE_NAME;
+    vi.spyOn(DynamoDBDocumentClient, 'from').mockReturnValue({
+      send,
+    } as unknown as DynamoDBDocumentClient);
+  });
+
+  it('GET before any designate returns currentSeat null', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    const body = responseBody(result!);
+    expect(Object.keys(body)).toEqual(['currentSeat']);
+    expect(body.currentSeat).toBeNull();
+  });
+
+  it('GET with seats present but no designate returns currentSeat null', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: 'CURSOR',
+          currentSeat: null,
+          seatOrder: [SEAT_ID_1, SEAT_ID_2],
+        },
+      });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    expect(responseBody(result!)).toEqual({ currentSeat: null });
+  });
+
+  it('PUT designates first seat and GET reports same seat', async () => {
+    let cursorCurrentSeat: string | null = null;
+    const seatOrder = [SEAT_ID_1, SEAT_ID_2];
+
+    send.mockImplementation(async (cmd) => {
+      if (cmd instanceof GetCommand) {
+        const key = cmd.input.Key;
+        if (key?.keyHash !== undefined) {
+          return { Item: { gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.matchId === MATCH_ID && key?.sk === undefined) {
+          return { Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.sk === `SEAT#${SEAT_ID_1}`) {
+          return {
+            Item: {
+              matchId: MATCH_ID,
+              sk: `SEAT#${SEAT_ID_1}`,
+              seatId: SEAT_ID_1,
+              createdAt: '2026-08-27T12:00:00.000Z',
+            },
+          };
+        }
+        if (key?.sk === 'CURSOR') {
+          return {
+            Item: {
+              matchId: MATCH_ID,
+              sk: 'CURSOR',
+              currentSeat: cursorCurrentSeat,
+              seatOrder,
+            },
+          };
+        }
+      }
+      if (cmd instanceof PutCommand) {
+        const item = cmd.input.Item as { currentSeat?: string };
+        cursorCurrentSeat = item.currentSeat ?? null;
+      }
+      return {};
+    });
+
+    const putResult = await handler(
+      eventWithAuth(
+        'PUT',
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1 }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(putResult!)).toBe(200);
+    const putBody = responseBody(putResult!);
+    expect(Object.keys(putBody)).toEqual(['currentSeat']);
+    expect(putBody.currentSeat).toBe(SEAT_ID_1);
+
+    const getResult = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(getResult!)).toBe(200);
+    expect(responseBody(getResult!)).toEqual({ currentSeat: SEAT_ID_1 });
+  });
+
+  it('PUT unknown seat returns 404 seat_not_found without changing currentSeat', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const putResult = await handler(
+      eventWithAuth(
+        'PUT',
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_OTHER }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(putResult!)).toBe(404);
+    expect(responseBody(putResult!)).toMatchObject({ code: 'seat_not_found' });
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: 'CURSOR',
+          currentSeat: SEAT_ID_1,
+          seatOrder: [SEAT_ID_1],
+        },
+      });
+
+    const getResult = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(responseBody(getResult!)).toEqual({ currentSeat: SEAT_ID_1 });
+  });
+
+  it.each([
+    ['missing body', undefined],
+    ['empty body', ''],
+    ['empty seatId', JSON.stringify({ seatId: '' })],
+    ['whitespace seatId', JSON.stringify({ seatId: '   ' })],
+    ['non-string seatId', JSON.stringify({ seatId: 123 })],
+    ['unparseable JSON', '{not json}'],
+  ])('PUT with %s returns 400 invalid_request', async (_label, body) => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      });
+
+    const result = await handler(
+      eventWithAuth('PUT', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`, MATCH_ID, body),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(400);
+    expect(responseBody(result!)).toMatchObject({ code: 'invalid_request' });
+    expect(send.mock.calls.some(([cmd]) => cmd instanceof PutCommand)).toBe(false);
+  });
+
+  it('GET and PUT success bodies omit hidden-view and other fields', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: 'CURSOR',
+          currentSeat: null,
+          seatOrder: [SEAT_ID_1],
+        },
+      });
+
+    const getResult = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(Object.keys(responseBody(getResult!))).toEqual(['currentSeat']);
+
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: `SEAT#${SEAT_ID_1}`,
+          seatId: SEAT_ID_1,
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          sk: 'CURSOR',
+          currentSeat: null,
+          seatOrder: [SEAT_ID_1],
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const putResult = await handler(
+      eventWithAuth(
+        'PUT',
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID,
+        JSON.stringify({ seatId: SEAT_ID_1 }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(Object.keys(responseBody(putResult!))).toEqual(['currentSeat']);
+    expect(responseBody(putResult!)).not.toHaveProperty('view');
+    expect(responseBody(putResult!)).not.toHaveProperty('seatOrder');
+    expect(responseBody(putResult!)).not.toHaveProperty('payload');
+  });
+
+  it('returns 401 game_auth_required when Authorization is absent', async () => {
+    const result = await handler(eventWithAuth('GET', undefined), {} as never, () => {});
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_required' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 game_auth_invalid for an unknown SDK key', async () => {
+    send.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('GET', 'Bearer turnur_sk_11111111111111111111111111111111'),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(401);
+    expect(responseBody(result!)).toMatchObject({ code: 'game_auth_invalid' });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it('returns 404 match_not_found when match item is absent', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(404);
+    expect(responseBody(result!)).toMatchObject({ code: 'match_not_found' });
+    expect(send.mock.calls.some(([cmd]) => cmd.input?.Key?.sk === 'CURSOR')).toBe(false);
+  });
+
+  it('returns 403 match_forbidden when match belongs to another game', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: {
+          matchId: MATCH_ID,
+          gameId: OTHER_GAME_ID,
+          status: 'created',
+          createdAt: '2026-08-27T12:00:00.000Z',
+        },
+      });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(403);
+    const body = responseBody(result!);
+    expect(body).toMatchObject({ code: 'match_forbidden' });
+    expect(body).not.toHaveProperty('matchId');
+    expect(body).not.toHaveProperty('currentSeat');
+    expect(send.mock.calls.some(([cmd]) => cmd.input?.Key?.sk === 'CURSOR')).toBe(false);
+  });
+
+  it('turn on match A does not appear on GET for match B', async () => {
+    send.mockImplementation(async (cmd) => {
+      if (cmd instanceof GetCommand) {
+        const key = cmd.input.Key;
+        if (key?.keyHash !== undefined) {
+          return { Item: { gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.matchId === MATCH_ID_B && key?.sk === undefined) {
+          return { Item: { matchId: MATCH_ID_B, gameId: DEV_FIXTURE_GAME_ID } };
+        }
+        if (key?.matchId === MATCH_ID_B && key?.sk === 'CURSOR') {
+          return { Item: undefined };
+        }
+      }
+      return {};
+    });
+
+    const result = await handler(
+      eventWithAuth('GET', `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`, MATCH_ID_B),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(200);
+    expect(responseBody(result!)).toEqual({ currentSeat: null });
+  });
+
+  it('PUT on match B using match A seatId returns 404 seat_not_found', async () => {
+    send
+      .mockResolvedValueOnce({ Item: { gameId: DEV_FIXTURE_GAME_ID } })
+      .mockResolvedValueOnce({
+        Item: { matchId: MATCH_ID_B, gameId: DEV_FIXTURE_GAME_ID },
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(
+      eventWithAuth(
+        'PUT',
+        `Bearer ${DEV_FIXTURE_PLAINTEXT_SDK_KEY}`,
+        MATCH_ID_B,
+        JSON.stringify({ seatId: SEAT_ID_1 }),
+      ),
+      {} as never,
+      () => {},
+    );
+
+    expect(statusCode(result!)).toBe(404);
+    expect(responseBody(result!)).toMatchObject({ code: 'seat_not_found' });
+  });
+});

--- a/infra/cdk/lambda/matches-turn-handler.ts
+++ b/infra/cdk/lambda/matches-turn-handler.ts
@@ -1,0 +1,245 @@
+/**
+ * GET /v1/matches/{matchId}/turn — read current turn designation.
+ * PUT /v1/matches/{matchId}/turn — designate current seat.
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+
+import { requireGameAuth } from '../lib/game-auth/require-game-auth';
+
+export type TurnResponseBody = {
+  currentSeat: string | null;
+};
+
+type MatchErrorCode = 'match_not_found' | 'match_forbidden';
+
+type MatchErrorBody = {
+  code: MatchErrorCode;
+  message: string;
+  hint: string;
+};
+
+type InvalidRequestBody = {
+  code: 'invalid_request';
+  message: string;
+  hint: string;
+};
+
+type SeatNotFoundBody = {
+  code: 'seat_not_found';
+  message: string;
+  hint: string;
+};
+
+type CursorItem = {
+  currentSeat?: string | null;
+  seatOrder?: string[];
+};
+
+function jsonResponse(statusCode: number, body: unknown): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+}
+
+function matchErrorResponse(
+  statusCode: number,
+  body: MatchErrorBody,
+): APIGatewayProxyResultV2 {
+  return jsonResponse(statusCode, body);
+}
+
+function buildMatchNotFoundResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(404, {
+    code: 'match_not_found',
+    message: 'Match not found',
+    hint: 'Verify the matchId exists and was created via POST /v1/matches for your game.',
+  });
+}
+
+function buildMatchForbiddenResponse(): APIGatewayProxyResultV2 {
+  return matchErrorResponse(403, {
+    code: 'match_forbidden',
+    message: 'Match belongs to another game',
+    hint: 'Use the SDK key for the game that created this match.',
+  });
+}
+
+function buildInvalidRequestResponse(): APIGatewayProxyResultV2 {
+  const body: InvalidRequestBody = {
+    code: 'invalid_request',
+    message: 'Invalid request',
+    hint: 'Provide a seatId in the request body.',
+  };
+  return jsonResponse(400, body);
+}
+
+function buildSeatNotFoundResponse(): APIGatewayProxyResultV2 {
+  const body: SeatNotFoundBody = {
+    code: 'seat_not_found',
+    message: 'Seat not found',
+    hint: 'Create the seat via POST /v1/matches/{matchId}/seats before designating it or submitting a move.',
+  };
+  return jsonResponse(404, body);
+}
+
+function parseSeatId(body: string | undefined): string | null {
+  if (body === undefined || body === '') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(body) as { seatId?: unknown };
+    if (typeof parsed.seatId !== 'string') {
+      return null;
+    }
+    const trimmed = parsed.seatId.trim();
+    if (trimmed === '') {
+      return null;
+    }
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+async function assertMatchOwnership(
+  docClient: DynamoDBDocumentClient,
+  matchRegistryTable: string,
+  matchId: string,
+  gameId: string,
+): Promise<APIGatewayProxyResultV2 | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: matchRegistryTable,
+      Key: { matchId },
+    }),
+  );
+
+  if (!result.Item) {
+    return buildMatchNotFoundResponse();
+  }
+
+  if (result.Item.gameId !== gameId) {
+    return buildMatchForbiddenResponse();
+  }
+
+  return null;
+}
+
+async function handleGetTurn(
+  docClient: DynamoDBDocumentClient,
+  matchStateTable: string,
+  matchId: string,
+): Promise<APIGatewayProxyResultV2> {
+  const cursorResult = await docClient.send(
+    new GetCommand({
+      TableName: matchStateTable,
+      Key: { matchId, sk: 'CURSOR' },
+    }),
+  );
+
+  if (!cursorResult.Item || cursorResult.Item.currentSeat == null) {
+    const body: TurnResponseBody = { currentSeat: null };
+    return jsonResponse(200, body);
+  }
+
+  const body: TurnResponseBody = {
+    currentSeat: String(cursorResult.Item.currentSeat),
+  };
+  return jsonResponse(200, body);
+}
+
+async function handlePutTurn(
+  docClient: DynamoDBDocumentClient,
+  matchStateTable: string,
+  matchId: string,
+  body: string | undefined,
+): Promise<APIGatewayProxyResultV2> {
+  const seatId = parseSeatId(body);
+  if (seatId === null) {
+    return buildInvalidRequestResponse();
+  }
+
+  const seatResult = await docClient.send(
+    new GetCommand({
+      TableName: matchStateTable,
+      Key: { matchId, sk: `SEAT#${seatId}` },
+    }),
+  );
+
+  if (!seatResult.Item) {
+    return buildSeatNotFoundResponse();
+  }
+
+  const cursorResult = await docClient.send(
+    new GetCommand({
+      TableName: matchStateTable,
+      Key: { matchId, sk: 'CURSOR' },
+    }),
+  );
+
+  const existing = (cursorResult.Item ?? {}) as CursorItem;
+
+  await docClient.send(
+    new PutCommand({
+      TableName: matchStateTable,
+      Item: {
+        matchId,
+        sk: 'CURSOR',
+        currentSeat: seatId,
+        seatOrder: existing.seatOrder ?? [],
+      },
+    }),
+  );
+
+  const responseBody: TurnResponseBody = { currentSeat: seatId };
+  return jsonResponse(200, responseBody);
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const auth = await requireGameAuth(event);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const matchId = event.pathParameters?.matchId;
+  if (!matchId) {
+    return buildMatchNotFoundResponse();
+  }
+
+  const matchRegistryTable = process.env.MATCH_REGISTRY_TABLE_NAME;
+  const matchStateTable = process.env.MATCH_STATE_TABLE_NAME;
+  if (!matchRegistryTable) {
+    throw new Error('MATCH_REGISTRY_TABLE_NAME is not configured');
+  }
+  if (!matchStateTable) {
+    throw new Error('MATCH_STATE_TABLE_NAME is not configured');
+  }
+
+  const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+  const ownershipError = await assertMatchOwnership(
+    docClient,
+    matchRegistryTable,
+    matchId,
+    auth.context.gameId,
+  );
+  if (ownershipError) {
+    return ownershipError;
+  }
+
+  const method = event.requestContext.http.method;
+
+  if (method === 'GET') {
+    return handleGetTurn(docClient, matchStateTable, matchId);
+  }
+
+  if (method === 'PUT') {
+    return handlePutTurn(docClient, matchStateTable, matchId, event.body);
+  }
+
+  return jsonResponse(405, { message: 'Method Not Allowed' });
+};

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -84,16 +84,6 @@ class MatchMoveLogWriteProbeStack extends TurnurApiStack {
   }
 }
 
-function policyStatements(template: Template): Array<{
-  Action?: string | string[];
-  Resource?: string | string[];
-}> {
-  const policies = template.findResources('AWS::IAM::Policy');
-  return Object.values(policies).flatMap(
-    (policy) => policy.Properties?.PolicyDocument?.Statement ?? [],
-  );
-}
-
 function lambdaPolicyStatements(
   template: Template,
   logicalIdFragment: string,
@@ -175,7 +165,7 @@ describe('TurnurApiStack', () => {
       Runtime: 'nodejs22.x',
     });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Route', 6);
+    template.resourceCountIs('AWS::ApiGatewayV2::Route', 9);
     template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
       RouteKey: 'GET /v1/health',
       AuthorizationType: 'NONE',
@@ -200,8 +190,20 @@ describe('TurnurApiStack', () => {
       RouteKey: 'GET /v1/matches/{matchId}/seats',
       AuthorizationType: 'NONE',
     });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'GET /v1/matches/{matchId}/turn',
+      AuthorizationType: 'NONE',
+    });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'PUT /v1/matches/{matchId}/turn',
+      AuthorizationType: 'NONE',
+    });
+    template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+      RouteKey: 'POST /v1/matches/{matchId}/moves',
+      AuthorizationType: 'NONE',
+    });
 
-    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 5);
+    template.resourceCountIs('AWS::ApiGatewayV2::Integration', 7);
     template.hasResourceProperties('AWS::ApiGatewayV2::Integration', {
       IntegrationType: 'AWS_PROXY',
       PayloadFormatVersion: '2.0',
@@ -453,7 +455,7 @@ describe('TurnurApiStack', () => {
     const app = new cdk.App();
     const stack = new MatchMoveLogReadProbeStack(app, 'TurnurApiStackMatchMoveLogReadTest');
     const template = Template.fromStack(stack);
-    const statements = policyStatements(template);
+    const statements = lambdaPolicyStatements(template, 'MatchMoveLogReadProbeFn');
 
     template.hasResourceProperties('AWS::Lambda::Function', {
       Runtime: 'nodejs22.x',
@@ -473,7 +475,7 @@ describe('TurnurApiStack', () => {
     const app = new cdk.App();
     const stack = new MatchMoveLogWriteProbeStack(app, 'TurnurApiStackMatchMoveLogWriteTest');
     const template = Template.fromStack(stack);
-    const statements = policyStatements(template);
+    const statements = lambdaPolicyStatements(template, 'MatchMoveLogWriteProbeFn');
 
     template.hasResourceProperties('AWS::Lambda::Function', {
       Runtime: 'nodejs22.x',
@@ -510,5 +512,51 @@ describe('TurnurApiStack', () => {
     expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchMoveLog')).toBe(false);
     expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchMoveLog')).toBe(false);
     expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchMoveLog')).toBe(false);
+  });
+
+  it('MatchesTurnFn receives MatchState and MatchRegistry env and IAM without MatchMoveLog', () => {
+    const app = new cdk.App();
+    const stack = new TurnurApiStack(app, 'TurnurApiStackMatchesTurnTest');
+    const template = Template.fromStack(stack);
+    const statements = lambdaPolicyStatements(template, 'MatchesTurnFn');
+
+    const env = lambdaEnvVars(template, 'MatchesTurnFn');
+    expect(env).toMatchObject({
+      GAME_REGISTRY_TABLE_NAME: expect.anything(),
+      MATCH_REGISTRY_TABLE_NAME: expect.anything(),
+      MATCH_STATE_TABLE_NAME: expect.anything(),
+    });
+    expect(env).not.toHaveProperty('MATCH_MOVE_LOG_TABLE_NAME');
+
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchRegistry')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchState')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchState')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchState')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchMoveLog')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchMoveLog')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchMoveLog')).toBe(false);
+  });
+
+  it('MatchesMovesFn receives MatchMoveLog and MatchState read env and IAM without MatchState write', () => {
+    const app = new cdk.App();
+    const stack = new TurnurApiStack(app, 'TurnurApiStackMatchesMovesTest');
+    const template = Template.fromStack(stack);
+    const statements = lambdaPolicyStatements(template, 'MatchesMovesFn');
+
+    const env = lambdaEnvVars(template, 'MatchesMovesFn');
+    expect(env).toMatchObject({
+      GAME_REGISTRY_TABLE_NAME: expect.anything(),
+      MATCH_REGISTRY_TABLE_NAME: expect.anything(),
+      MATCH_STATE_TABLE_NAME: expect.anything(),
+      MATCH_MOVE_LOG_TABLE_NAME: expect.anything(),
+    });
+
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchRegistry')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchState')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchState')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchState')).toBe(false);
+    expect(hasActionOnTableResource(statements, 'dynamodb:Query', 'MatchMoveLog')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:PutItem', 'MatchMoveLog')).toBe(true);
+    expect(hasActionOnTableResource(statements, 'dynamodb:GetItem', 'MatchMoveLog')).toBe(false);
   });
 });

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -27,6 +27,8 @@ export class TurnurApiStack extends cdk.Stack {
   public readonly matchesAttachFunction: lambdaNodejs.NodejsFunction;
   public readonly matchesProbeFunction: lambdaNodejs.NodejsFunction;
   public readonly matchesSeatsFunction: lambdaNodejs.NodejsFunction;
+  public readonly matchesTurnFunction: lambdaNodejs.NodejsFunction;
+  public readonly matchesMovesFunction: lambdaNodejs.NodejsFunction;
   public readonly gameRegistryTable: dynamodb.Table;
   public readonly matchRegistryTable: dynamodb.Table;
   public readonly matchStateTable: dynamodb.Table;
@@ -213,6 +215,47 @@ export class TurnurApiStack extends cdk.Stack {
       path: '/v1/matches/{matchId}/seats',
       methods: [apigwv2.HttpMethod.POST, apigwv2.HttpMethod.GET],
       integration: matchesSeatsIntegration,
+    });
+
+    this.matchesTurnFunction = this.createProtectedNodejsFunction('MatchesTurnFn', {
+      entry: path.join(__dirname, '../lambda/matches-turn-handler.ts'),
+      handler: 'handler',
+      description: 'GET/PUT /v1/matches/{matchId}/turn — read and designate current seat',
+      matchRegistryRead: true,
+      matchStateRead: true,
+      matchStateWrite: true,
+    });
+
+    const matchesTurnIntegration = new integrations.HttpLambdaIntegration(
+      'MatchesTurnInt',
+      this.matchesTurnFunction,
+    );
+
+    this.httpApi.addRoutes({
+      path: '/v1/matches/{matchId}/turn',
+      methods: [apigwv2.HttpMethod.GET, apigwv2.HttpMethod.PUT],
+      integration: matchesTurnIntegration,
+    });
+
+    this.matchesMovesFunction = this.createProtectedNodejsFunction('MatchesMovesFn', {
+      entry: path.join(__dirname, '../lambda/matches-moves-handler.ts'),
+      handler: 'handler',
+      description: 'POST /v1/matches/{matchId}/moves — append on-turn move',
+      matchRegistryRead: true,
+      matchStateRead: true,
+      matchMoveLogRead: true,
+      matchMoveLogWrite: true,
+    });
+
+    const matchesMovesIntegration = new integrations.HttpLambdaIntegration(
+      'MatchesMovesInt',
+      this.matchesMovesFunction,
+    );
+
+    this.httpApi.addRoutes({
+      path: '/v1/matches/{matchId}/moves',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: matchesMovesIntegration,
     });
   }
 


### PR DESCRIPTION
## Summary
- Add `GET` and `PUT /v1/matches/{matchId}/turn` so the authenticated game can read and designate `currentSeat` without auto-advancing after move accept.
- Add `POST /v1/matches/{matchId}/moves` to append on-turn moves with opaque payload, conditional seq allocation, and `409 illegal_turn` on off-turn or concurrent double-submit.
- Wire two Lambdas (`MatchesTurnFn`, `MatchesMovesFn`) with least-privilege IAM; HTTP route count 6 → 9.

## Test plan
- [x] `npm test` in `infra/cdk/` (78 tests)
- [x] `npm run synth` in `infra/cdk/`
- [ ] Handler tests cover auth, ownership, designate/get turn, accept/reject moves, isolation across matches
- [ ] CDK tests assert route count 9 and per-Lambda IAM boundaries (turn: no MoveLog; moves: no MatchState write)

Closes #31