### PR TITLE
Add TypeScript SDK match authority methods (#34)

### DIFF
--- a/packages/turnur-sdk/src/client.test.ts
+++ b/packages/turnur-sdk/src/client.test.ts
@@ -5,6 +5,18 @@ import { TurnurApiError } from './errors.js';
 
 const API_KEY = 'turnur_sk_0123456789abcdef0123456789abcdef';
 const BASE_URL = 'https://api.turnur.example';
+const MATCH_ID = '550e8400-e29b-41d4-a716-446655440000';
+const SEAT_ID = 'seat-abc-123';
+const SEAT_ID_2 = 'seat-def-456';
+const HIDDEN_VIEW = { cards: ['ace', 'king'], playerName: 'secret' };
+
+function mockFetch(response: Response) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+}
+
+function mockFetchFn(fn: ReturnType<typeof vi.fn>) {
+  vi.stubGlobal('fetch', fn);
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -278,5 +290,428 @@ describe('createTurnurClient.match', () => {
       expect(String(apiError)).not.toContain(API_KEY);
       return true;
     });
+  });
+});
+
+describe('createTurnurClient.match.seat', () => {
+  it('seat.create sends POST with no body and returns seatId and currentSeat', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ seatId: SEAT_ID, currentSeat: null }),
+        { status: 201 },
+      ),
+    );
+    mockFetchFn(fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    const result = await client.match.seat.create(MATCH_ID);
+
+    expect(result).toEqual({ seatId: SEAT_ID, currentSeat: null });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/v1/matches/${encodeURIComponent(MATCH_ID)}/seats`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+    expect(init.headers).toMatchObject({
+      Authorization: `Bearer ${API_KEY}`,
+      Accept: 'application/json',
+    });
+  });
+
+  it('seat.list returns roster and currentSeat without hidden views', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          seats: [
+            { seatId: SEAT_ID, createdAt: '2026-08-27T12:00:00.000Z', view: HIDDEN_VIEW },
+            { seatId: SEAT_ID_2, createdAt: '2026-08-27T12:01:00.000Z', hiddenView: HIDDEN_VIEW },
+          ],
+          currentSeat: SEAT_ID,
+          views: [HIDDEN_VIEW],
+        }),
+        { status: 200 },
+      ),
+    );
+    mockFetchFn(fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    const result = await client.match.seat.list(MATCH_ID);
+
+    expect(result).toEqual({
+      seats: [
+        { seatId: SEAT_ID, createdAt: '2026-08-27T12:00:00.000Z' },
+        { seatId: SEAT_ID_2, createdAt: '2026-08-27T12:01:00.000Z' },
+      ],
+      currentSeat: SEAT_ID,
+    });
+    expect(JSON.stringify(result)).not.toContain('cards');
+  });
+
+  it('seat.list returns empty roster when no seats exist', async () => {
+    mockFetch(
+      new Response(JSON.stringify({ seats: [], currentSeat: null }), { status: 200 }),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await expect(client.match.seat.list(MATCH_ID)).resolves.toEqual({
+      seats: [],
+      currentSeat: null,
+    });
+  });
+
+  it('URL-encodes matchId in seat paths', async () => {
+    const matchId = 'match/with/slashes';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ seatId: SEAT_ID, currentSeat: null }), { status: 201 }),
+    );
+    mockFetchFn(fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await client.match.seat.create(matchId);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(`${BASE_URL}/v1/matches/${encodeURIComponent(matchId)}/seats`);
+  });
+});
+
+describe('createTurnurClient.match.turn', () => {
+  it('turn.get returns currentSeat', async () => {
+    mockFetch(
+      new Response(JSON.stringify({ currentSeat: SEAT_ID, view: HIDDEN_VIEW }), { status: 200 }),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await expect(client.match.turn.get(MATCH_ID)).resolves.toEqual({ currentSeat: SEAT_ID });
+  });
+
+  it('turn.get returns null currentSeat when none designated', async () => {
+    mockFetch(new Response(JSON.stringify({ currentSeat: null }), { status: 200 }));
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await expect(client.match.turn.get(MATCH_ID)).resolves.toEqual({ currentSeat: null });
+  });
+
+  it('turn.set sends PUT with seatId body and returns currentSeat', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ currentSeat: SEAT_ID }), { status: 200 }),
+    );
+    mockFetchFn(fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    const result = await client.match.turn.set(MATCH_ID, SEAT_ID);
+
+    expect(result).toEqual({ currentSeat: SEAT_ID });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/v1/matches/${encodeURIComponent(MATCH_ID)}/turn`);
+    expect(init.method).toBe('PUT');
+    expect(init.body).toBe(JSON.stringify({ seatId: SEAT_ID }));
+    expect(init.headers).toMatchObject({
+      Authorization: `Bearer ${API_KEY}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    });
+  });
+});
+
+describe('createTurnurClient.match.move', () => {
+  it('move.create sends POST with seatId and payload and returns without payload', async () => {
+    const payload = { action: 'play', card: 'ace' };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          seq: 1,
+          seatId: SEAT_ID,
+          createdAt: '2026-08-27T12:00:00.000Z',
+          currentSeat: SEAT_ID,
+          payload,
+          view: HIDDEN_VIEW,
+        }),
+        { status: 201 },
+      ),
+    );
+    mockFetchFn(fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    const result = await client.match.move.create(MATCH_ID, { seatId: SEAT_ID, payload });
+
+    expect(result).toEqual({
+      seq: 1,
+      seatId: SEAT_ID,
+      createdAt: '2026-08-27T12:00:00.000Z',
+      currentSeat: SEAT_ID,
+    });
+    expect(result).not.toHaveProperty('payload');
+    expect(result).not.toHaveProperty('view');
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/v1/matches/${encodeURIComponent(MATCH_ID)}/moves`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ seatId: SEAT_ID, payload }));
+  });
+
+  it('move.create throws TurnurApiError on 409 illegal_turn', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({ code: 'illegal_turn', message: 'Not this seat\'s turn' }),
+        { status: 409 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(
+      client.match.move.create(MATCH_ID, { seatId: SEAT_ID, payload: {} }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      const apiError = error as TurnurApiError;
+      expect(apiError.status).toBe(409);
+      expect(apiError.code).toBe('illegal_turn');
+      expect(apiError.message).toBe('Not this seat\'s turn');
+      expect(String(apiError)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+});
+
+describe('createTurnurClient.match.view', () => {
+  it('view.put sends PUT with view body and returns seatId only', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ seatId: SEAT_ID, view: HIDDEN_VIEW }), { status: 200 }),
+    );
+    mockFetchFn(fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    const result = await client.match.view.put(MATCH_ID, SEAT_ID, HIDDEN_VIEW);
+
+    expect(result).toEqual({ seatId: SEAT_ID });
+    expect(result).not.toHaveProperty('view');
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      `${BASE_URL}/v1/matches/${encodeURIComponent(MATCH_ID)}/seats/${encodeURIComponent(SEAT_ID)}/view`,
+    );
+    expect(init.method).toBe('PUT');
+    expect(init.body).toBe(JSON.stringify({ view: HIDDEN_VIEW }));
+  });
+
+  it('view.get returns seatId and view for requested seat only', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({
+          seatId: SEAT_ID,
+          view: HIDDEN_VIEW,
+          views: [{ seatId: SEAT_ID_2, view: { other: true } }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    const result = await client.match.view.get(MATCH_ID, SEAT_ID);
+
+    expect(Object.keys(result).sort()).toEqual(['seatId', 'view']);
+    expect(result).toEqual({ seatId: SEAT_ID, view: HIDDEN_VIEW });
+  });
+
+  it('view.get returns null view when unset', async () => {
+    mockFetch(
+      new Response(JSON.stringify({ seatId: SEAT_ID, view: null }), { status: 200 }),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await expect(client.match.view.get(MATCH_ID, SEAT_ID)).resolves.toEqual({
+      seatId: SEAT_ID,
+      view: null,
+    });
+  });
+
+  it('URL-encodes seatId in view paths', async () => {
+    const seatId = 'seat/with/slashes';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ seatId, view: null }), { status: 200 }),
+    );
+    mockFetchFn(fetchMock);
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await client.match.view.get(MATCH_ID, seatId);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(
+      `${BASE_URL}/v1/matches/${encodeURIComponent(MATCH_ID)}/seats/${encodeURIComponent(seatId)}/view`,
+    );
+  });
+
+  it('view.put error does not contain hidden view fixture', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({ code: 'seat_not_found', message: 'Seat not found' }),
+        { status: 404 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(
+      client.match.view.put(MATCH_ID, SEAT_ID, HIDDEN_VIEW),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      expect(String(error)).not.toContain('ace');
+      expect(String(error)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+});
+
+describe('createTurnurClient.match.moves', () => {
+  it('moves.list returns items with payload in accept order', async () => {
+    const payloadA = { action: 'play', card: 'ace' };
+    const payloadB = { action: 'pass' };
+    mockFetch(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              seq: 1,
+              seatId: SEAT_ID,
+              payload: payloadA,
+              createdAt: '2026-08-27T12:00:00.000Z',
+            },
+            {
+              seq: 2,
+              seatId: SEAT_ID_2,
+              payload: payloadB,
+              createdAt: '2026-08-27T12:01:00.000Z',
+            },
+          ],
+          view: HIDDEN_VIEW,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    const result = await client.match.moves.list(MATCH_ID);
+
+    expect(result).toEqual({
+      items: [
+        { seq: 1, seatId: SEAT_ID, payload: payloadA, createdAt: '2026-08-27T12:00:00.000Z' },
+        { seq: 2, seatId: SEAT_ID_2, payload: payloadB, createdAt: '2026-08-27T12:01:00.000Z' },
+      ],
+    });
+    expect(result).not.toHaveProperty('view');
+    expect(JSON.stringify(result)).not.toContain('cards');
+  });
+
+  it('moves.list returns empty items when no moves exist', async () => {
+    mockFetch(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+    await expect(client.match.moves.list(MATCH_ID)).resolves.toEqual({ items: [] });
+  });
+});
+
+describe('createTurnurClient.match authority errors', () => {
+  it('throws TurnurApiError on 400 invalid_request', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({ code: 'invalid_request', message: 'Missing seatId' }),
+        { status: 400 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.turn.set(MATCH_ID, '')).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      const apiError = error as TurnurApiError;
+      expect(apiError.status).toBe(400);
+      expect(apiError.code).toBe('invalid_request');
+      expect(apiError.message).toBe('Missing seatId');
+      expect(String(apiError)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+
+  it('throws TurnurApiError on 401 game_auth_required', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({ code: 'game_auth_required', message: 'Authorization required' }),
+        { status: 401 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.seat.list(MATCH_ID)).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      const apiError = error as TurnurApiError;
+      expect(apiError.status).toBe(401);
+      expect(apiError.code).toBe('game_auth_required');
+      expect(String(apiError)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+
+  it('throws TurnurApiError on 403 match_forbidden', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({ code: 'match_forbidden', message: 'Match belongs to another game' }),
+        { status: 403 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.moves.list(MATCH_ID)).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(TurnurApiError);
+      const apiError = error as TurnurApiError;
+      expect(apiError.status).toBe(403);
+      expect(apiError.code).toBe('match_forbidden');
+      expect(String(apiError)).not.toContain(API_KEY);
+      return true;
+    });
+  });
+
+  it('throws TurnurApiError on 404 seat_not_found', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({ code: 'seat_not_found', message: 'Seat not found' }),
+        { status: 404 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.turn.set(MATCH_ID, 'unknown-seat')).rejects.toSatisfy(
+      (error: unknown) => {
+        expect(error).toBeInstanceOf(TurnurApiError);
+        const apiError = error as TurnurApiError;
+        expect(apiError.status).toBe(404);
+        expect(apiError.code).toBe('seat_not_found');
+        expect(String(apiError)).not.toContain(API_KEY);
+        return true;
+      },
+    );
+  });
+
+  it('throws TurnurApiError on 404 match_not_found', async () => {
+    mockFetch(
+      new Response(
+        JSON.stringify({ code: 'match_not_found', message: 'Match not found' }),
+        { status: 404 },
+      ),
+    );
+
+    const client = createTurnurClient({ baseUrl: BASE_URL, apiKey: API_KEY });
+
+    await expect(client.match.seat.create('missing-match')).rejects.toSatisfy(
+      (error: unknown) => {
+        expect(error).toBeInstanceOf(TurnurApiError);
+        const apiError = error as TurnurApiError;
+        expect(apiError.status).toBe(404);
+        expect(apiError.code).toBe('match_not_found');
+        expect(String(apiError)).not.toContain(API_KEY);
+        return true;
+      },
+    );
   });
 });

--- a/packages/turnur-sdk/src/client.ts
+++ b/packages/turnur-sdk/src/client.ts
@@ -1,6 +1,7 @@
 import {
   authenticatedGet,
   authenticatedPost,
+  authenticatedPut,
   throwStructuredError,
   throwUnauthorized,
 } from './http.js';
@@ -9,6 +10,13 @@ import type {
   GameMeResponse,
   MatchCreateResponse,
   MatchGetResponse,
+  MatchMoveCreateResponse,
+  MatchMovesListResponse,
+  MatchSeatCreateResponse,
+  MatchSeatListResponse,
+  MatchTurnResponse,
+  MatchViewGetResponse,
+  MatchViewPutResponse,
   TurnurClientConfig,
 } from './types.js';
 
@@ -19,8 +27,56 @@ export type TurnurClient = {
   match: {
     create(): Promise<MatchCreateResponse>;
     get(matchId: string): Promise<MatchGetResponse>;
+    seat: {
+      create(matchId: string): Promise<MatchSeatCreateResponse>;
+      list(matchId: string): Promise<MatchSeatListResponse>;
+    };
+    turn: {
+      get(matchId: string): Promise<MatchTurnResponse>;
+      set(matchId: string, seatId: string): Promise<MatchTurnResponse>;
+    };
+    move: {
+      create(
+        matchId: string,
+        input: { seatId: string; payload: unknown },
+      ): Promise<MatchMoveCreateResponse>;
+    };
+    view: {
+      put(matchId: string, seatId: string, view: unknown): Promise<MatchViewPutResponse>;
+      get(matchId: string, seatId: string): Promise<MatchViewGetResponse>;
+    };
+    moves: {
+      list(matchId: string): Promise<MatchMovesListResponse>;
+    };
   };
 };
+
+function handleMatchAuthorityErrors(status: number, body: unknown): void {
+  if (status === 401) {
+    throwUnauthorized(body);
+  }
+  if (status === 400 || status === 403 || status === 404 || status === 409) {
+    throwStructuredError(status, body);
+  }
+}
+
+function parseCurrentSeat(value: unknown, status: number): string | null {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  throw new TurnurApiError(status, 'Invalid response: invalid currentSeat');
+}
+
+function matchPath(matchId: string, suffix: string): string {
+  return `/v1/matches/${encodeURIComponent(matchId)}${suffix}`;
+}
+
+function seatViewPath(matchId: string, seatId: string): string {
+  return `/v1/matches/${encodeURIComponent(matchId)}/seats/${encodeURIComponent(seatId)}/view`;
+}
 
 export function createTurnurClient(config: TurnurClientConfig): TurnurClient {
   const { baseUrl, apiKey } = config;
@@ -69,7 +125,7 @@ export function createTurnurClient(config: TurnurClientConfig): TurnurClient {
       },
 
       async get(matchId: string): Promise<MatchGetResponse> {
-        const path = `/v1/matches/${encodeURIComponent(matchId)}`;
+        const path = matchPath(matchId, '');
         const { status, body } = await authenticatedGet(baseUrl, apiKey, path);
 
         if (status === 401) {
@@ -99,6 +155,223 @@ export function createTurnurClient(config: TurnurClientConfig): TurnurClient {
           status: response.status,
           createdAt: response.createdAt,
         };
+      },
+
+      seat: {
+        async create(matchId: string): Promise<MatchSeatCreateResponse> {
+          const path = matchPath(matchId, '/seats');
+          const { status, body } = await authenticatedPost(baseUrl, apiKey, path);
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 201) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          const response = body as Record<string, unknown>;
+          if (!body || typeof response.seatId !== 'string') {
+            throw new TurnurApiError(status, 'Invalid response: missing seatId');
+          }
+
+          return {
+            seatId: response.seatId,
+            currentSeat: parseCurrentSeat(response.currentSeat, status),
+          };
+        },
+
+        async list(matchId: string): Promise<MatchSeatListResponse> {
+          const path = matchPath(matchId, '/seats');
+          const { status, body } = await authenticatedGet(baseUrl, apiKey, path);
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 200) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          const response = body as Record<string, unknown>;
+          if (!body || !Array.isArray(response.seats)) {
+            throw new TurnurApiError(status, 'Invalid response: missing seats');
+          }
+
+          const seats = response.seats.map((seat, index) => {
+            const entry = seat as Record<string, unknown>;
+            if (typeof entry.seatId !== 'string' || typeof entry.createdAt !== 'string') {
+              throw new TurnurApiError(status, `Invalid response: invalid seat at index ${index}`);
+            }
+            return { seatId: entry.seatId, createdAt: entry.createdAt };
+          });
+
+          return {
+            seats,
+            currentSeat: parseCurrentSeat(response.currentSeat, status),
+          };
+        },
+      },
+
+      turn: {
+        async get(matchId: string): Promise<MatchTurnResponse> {
+          const path = matchPath(matchId, '/turn');
+          const { status, body } = await authenticatedGet(baseUrl, apiKey, path);
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 200) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          if (!body || !('currentSeat' in (body as object))) {
+            throw new TurnurApiError(status, 'Invalid response: missing currentSeat');
+          }
+
+          return {
+            currentSeat: parseCurrentSeat(
+              (body as Record<string, unknown>).currentSeat,
+              status,
+            ),
+          };
+        },
+
+        async set(matchId: string, seatId: string): Promise<MatchTurnResponse> {
+          const path = matchPath(matchId, '/turn');
+          const { status, body } = await authenticatedPut(baseUrl, apiKey, path, { seatId });
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 200) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          if (!body || !('currentSeat' in (body as object))) {
+            throw new TurnurApiError(status, 'Invalid response: missing currentSeat');
+          }
+
+          return {
+            currentSeat: parseCurrentSeat(
+              (body as Record<string, unknown>).currentSeat,
+              status,
+            ),
+          };
+        },
+      },
+
+      move: {
+        async create(
+          matchId: string,
+          input: { seatId: string; payload: unknown },
+        ): Promise<MatchMoveCreateResponse> {
+          const path = matchPath(matchId, '/moves');
+          const { status, body } = await authenticatedPost(baseUrl, apiKey, path, {
+            seatId: input.seatId,
+            payload: input.payload,
+          });
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 201) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          const response = body as Record<string, unknown>;
+          if (
+            !body ||
+            typeof response.seq !== 'number' ||
+            typeof response.seatId !== 'string' ||
+            typeof response.createdAt !== 'string'
+          ) {
+            throw new TurnurApiError(status, 'Invalid response: missing move fields');
+          }
+
+          return {
+            seq: response.seq,
+            seatId: response.seatId,
+            createdAt: response.createdAt,
+            currentSeat: parseCurrentSeat(response.currentSeat, status),
+          };
+        },
+      },
+
+      view: {
+        async put(
+          matchId: string,
+          seatId: string,
+          view: unknown,
+        ): Promise<MatchViewPutResponse> {
+          const path = seatViewPath(matchId, seatId);
+          const { status, body } = await authenticatedPut(baseUrl, apiKey, path, { view });
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 200) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          const response = body as Record<string, unknown>;
+          if (!body || typeof response.seatId !== 'string') {
+            throw new TurnurApiError(status, 'Invalid response: missing seatId');
+          }
+
+          return { seatId: response.seatId };
+        },
+
+        async get(matchId: string, seatId: string): Promise<MatchViewGetResponse> {
+          const path = seatViewPath(matchId, seatId);
+          const { status, body } = await authenticatedGet(baseUrl, apiKey, path);
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 200) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          const response = body as Record<string, unknown>;
+          if (!body || typeof response.seatId !== 'string' || !('view' in response)) {
+            throw new TurnurApiError(status, 'Invalid response: missing view fields');
+          }
+
+          return {
+            seatId: response.seatId,
+            view: response.view,
+          };
+        },
+      },
+
+      moves: {
+        async list(matchId: string): Promise<MatchMovesListResponse> {
+          const path = matchPath(matchId, '/moves');
+          const { status, body } = await authenticatedGet(baseUrl, apiKey, path);
+
+          handleMatchAuthorityErrors(status, body);
+
+          if (status !== 200) {
+            throw new TurnurApiError(status, `Request failed with status ${status}`);
+          }
+
+          const response = body as Record<string, unknown>;
+          if (!body || !Array.isArray(response.items)) {
+            throw new TurnurApiError(status, 'Invalid response: missing items');
+          }
+
+          const items = response.items.map((item, index) => {
+            const entry = item as Record<string, unknown>;
+            if (
+              typeof entry.seq !== 'number' ||
+              typeof entry.seatId !== 'string' ||
+              typeof entry.createdAt !== 'string' ||
+              !('payload' in entry)
+            ) {
+              throw new TurnurApiError(status, `Invalid response: invalid item at index ${index}`);
+            }
+            return {
+              seq: entry.seq,
+              seatId: entry.seatId,
+              payload: entry.payload,
+              createdAt: entry.createdAt,
+            };
+          });
+
+          return { items };
+        },
       },
     },
   };

--- a/packages/turnur-sdk/src/http.ts
+++ b/packages/turnur-sdk/src/http.ts
@@ -34,25 +34,59 @@ export async function authenticatedPost(
   baseUrl: string,
   apiKey: string,
   path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  const url = `${normalizeBaseUrl(baseUrl)}${path}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    Accept: 'application/json',
+  };
+
+  const init: RequestInit = { method: 'POST', headers };
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, init);
+
+  let responseBody: unknown;
+  const text = await response.text();
+  try {
+    responseBody = text ? JSON.parse(text) : null;
+  } catch {
+    responseBody = null;
+  }
+
+  return { status: response.status, body: responseBody };
+}
+
+export async function authenticatedPut(
+  baseUrl: string,
+  apiKey: string,
+  path: string,
+  body: unknown,
 ): Promise<{ status: number; body: unknown }> {
   const url = `${normalizeBaseUrl(baseUrl)}${path}`;
   const response = await fetch(url, {
-    method: 'POST',
+    method: 'PUT',
     headers: {
       Authorization: `Bearer ${apiKey}`,
       Accept: 'application/json',
+      'Content-Type': 'application/json',
     },
+    body: JSON.stringify(body),
   });
 
-  let body: unknown;
+  let responseBody: unknown;
   const text = await response.text();
   try {
-    body = text ? JSON.parse(text) : null;
+    responseBody = text ? JSON.parse(text) : null;
   } catch {
-    body = null;
+    responseBody = null;
   }
 
-  return { status: response.status, body };
+  return { status: response.status, body: responseBody };
 }
 
 export function throwStructuredError(status: number, body: unknown): never {

--- a/packages/turnur-sdk/src/index.ts
+++ b/packages/turnur-sdk/src/index.ts
@@ -6,5 +6,12 @@ export type {
   GameMeResponse,
   MatchCreateResponse,
   MatchGetResponse,
+  MatchMoveCreateResponse,
+  MatchMovesListResponse,
+  MatchSeatCreateResponse,
+  MatchSeatListResponse,
+  MatchTurnResponse,
+  MatchViewGetResponse,
+  MatchViewPutResponse,
   TurnurClientConfig,
 } from './types.js';

--- a/packages/turnur-sdk/src/types.ts
+++ b/packages/turnur-sdk/src/types.ts
@@ -17,6 +17,40 @@ export type MatchGetResponse = {
   createdAt: string;
 };
 
+export type MatchSeatCreateResponse = {
+  seatId: string;
+  currentSeat: string | null;
+};
+
+export type MatchSeatListResponse = {
+  seats: Array<{ seatId: string; createdAt: string }>;
+  currentSeat: string | null;
+};
+
+export type MatchTurnResponse = {
+  currentSeat: string | null;
+};
+
+export type MatchMoveCreateResponse = {
+  seq: number;
+  seatId: string;
+  createdAt: string;
+  currentSeat: string | null;
+};
+
+export type MatchViewPutResponse = {
+  seatId: string;
+};
+
+export type MatchViewGetResponse = {
+  seatId: string;
+  view: unknown;
+};
+
+export type MatchMovesListResponse = {
+  items: Array<{ seq: number; seatId: string; payload: unknown; createdAt: string }>;
+};
+
 export type ApiErrorBody = {
   code?: string;
   message?: string;


### PR DESCRIPTION
## Summary

- Extend `@turnur/sdk` with match-authority methods on `client.match`: `seat.create` / `seat.list`, `turn.get` / `turn.set`, `move.create`, `view.put` / `view.get`, and `moves.list`.
- Add `authenticatedPut` and optional JSON body support on `authenticatedPost`; all methods mirror the HTTP routes from #30–#33 with URL-encoded path segments and structured `TurnurApiError` handling.
- Shipped `game.me`, `match.create`, and `match.get` remain unchanged.

Closes #34

## Test plan

- [x] `npm run build && npm test` in `packages/turnur-sdk/` exits 0
- [x] Mocked success paths for each new method (method, path, auth header, body)
- [x] Empty `seat.list` and `moves.list` parse as empty collections
- [x] `turn.get` with `currentSeat: null` and `view.get` with `view: null` parse as success
- [x] Mocked 400/401/403/404/409 throw `TurnurApiError` with parsed code/message
- [x] Field projection strips hidden views from list/turn/move responses
- [x] `move.create` success does not echo `payload`; `moves.list` includes it
- [x] URL-encoding for `matchId` and `seatId` with slashes
- [x] Regression: `match.create` and `match.get` tests still pass
- [x] No logging of `apiKey`, Authorization, or view payloads in SDK source