### PR TITLE
Deploy TurnurApiStack from main after CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   infra-cdk:
     runs-on: ubuntu-latest
@@ -50,3 +54,54 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [infra-cdk]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    concurrency:
+      group: cdk-deploy
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: infra/cdk
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require deploy OIDC role
+        env:
+          ROLE: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+        run: |
+          if [ -z "$ROLE" ]; then
+            echo "::error::Set repository variable AWS_DEPLOY_ROLE_ARN to the IAM role ARN trusted via GitHub OIDC (see infra/cdk/README.md)."
+            exit 1
+          fi
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: infra/cdk/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy TurnurApiStack
+        run: npx cdk deploy TurnurApiStack --require-approval never
+      - name: Smoke GET /v1/health
+        run: |
+          set -euo pipefail
+          API_URL="$(aws cloudformation describe-stacks --stack-name TurnurApiStack \
+            --query "Stacks[0].Outputs[?OutputKey=='HttpApiUrl'].OutputValue" --output text)"
+          API_URL="${API_URL%/}"
+          if [ -z "$API_URL" ] || [ "$API_URL" = "None" ]; then
+            echo "::error::TurnurApiStack is missing HttpApiUrl output"
+            exit 1
+          fi
+          echo "Health URL: ${API_URL}/v1/health"
+          body="$(curl -sS -f "${API_URL}/v1/health")"
+          echo "$body"
+          python3 -c 'import json,sys; data=json.loads(sys.argv[1]); assert data.get("ok") is True, data' "$body"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Identity, chat, rooms, and media stay on the host platform (RiffSync or anything
 
 ## Infrastructure
 
-AWS CDK workspace lives under [`infra/cdk/`](infra/cdk/README.md). See that README for Node 22 setup and verify commands (`npm ci`, `npm run build`, `npm test`, `npm run synth`).
+AWS CDK workspace lives under [`infra/cdk/`](infra/cdk/README.md). See that README for Node 22 setup, verify commands (`npm ci`, `npm run build`, `npm test`, `npm run synth`), and production deploy. Pushes to `main` that change the stack auto-deploy `TurnurApiStack` after CI synth and tests pass.
 
 For game SDK key setup and verification (`GET /v1/health` → configure key → `GET /v1/game/me`), see [Game authentication onboarding](infra/cdk/README.md#game-authentication-onboarding) in the CDK README.
 

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -30,6 +30,28 @@ npm run synth
 - **`npm test`** - runs Vitest handler and stack assertions
 - **`npm run synth`** - emits CloudFormation templates under `cdk.out/` (no AWS credentials required)
 
+## Deploy
+
+There is one environment: **`TurnurApiStack`**. Pushes to `main` that change `infra/cdk/**` (or this workflow) run synth and tests, then `cdk deploy TurnurApiStack`. Pull requests never deploy.
+
+GitHub Actions assumes the role in repository variable **`AWS_DEPLOY_ROLE_ARN`** via OIDC. Optional **`AWS_REGION`** defaults to `us-east-1`. Set those on the repo (Settings → Secrets and variables → Actions → Variables). Prefer OIDC over long-lived access keys.
+
+IAM trust (`sts:AssumeRoleWithWebIdentity`) should restrict:
+
+- Issuer: `token.actions.githubusercontent.com`
+- Audience (`aud`): `sts.amazonaws.com`
+- Subject (`sub`): `repo:StacksOnTheRacks/turnur:ref:refs/heads/main`
+
+The role needs CDK deploy permissions for this stack (CloudFormation, S3 bootstrap assets, IAM pass-through, Lambda, API Gateway HTTP, DynamoDB, CloudWatch Logs). Bootstrap the target account/region once (`npx cdk bootstrap`) before the first CI deploy.
+
+After deploy, CI reads stack output **`HttpApiUrl`** and asserts `GET /v1/health` returns `{ "ok": true }`.
+
+Local deploy (same stack):
+
+```bash
+npx cdk deploy TurnurApiStack --require-approval never
+```
+
 ## HTTP API
 
 | Method | Path | Auth | Response |

--- a/infra/cdk/lib/turnur-api-stack.test.ts
+++ b/infra/cdk/lib/turnur-api-stack.test.ts
@@ -221,6 +221,10 @@ describe('TurnurApiStack', () => {
       PayloadFormatVersion: '2.0',
     });
 
+    template.hasOutput('HttpApiUrl', {
+      Export: { Name: 'HttpApiUrl' },
+    });
+
     template.resourceCountIs('AWS::ApiGatewayV2::Authorizer', 0);
 
     template.hasResourceProperties('AWS::Lambda::Function', {

--- a/infra/cdk/lib/turnur-api-stack.ts
+++ b/infra/cdk/lib/turnur-api-stack.ts
@@ -62,6 +62,11 @@ export class TurnurApiStack extends cdk.Stack {
       integration: healthIntegration,
     });
 
+    new cdk.CfnOutput(this, 'HttpApiUrl', {
+      value: this.httpApi.apiEndpoint,
+      exportName: 'HttpApiUrl',
+    });
+
     this.gameRegistryTable = new dynamodb.Table(this, 'GameRegistry', {
       partitionKey: { name: 'keyHash', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,


### PR DESCRIPTION
## Summary
- Add a `deploy` job to CI that runs only on push to `main` after `infra-cdk` passes, using GitHub OIDC (`AWS_DEPLOY_ROLE_ARN`) to `cdk deploy TurnurApiStack`.
- Emit `HttpApiUrl` from the stack and smoke `GET /v1/health` after deploy.
- Document the single-stack deploy path. Pull requests never deploy.

## Test plan
- [ ] PR CI: `infra-cdk` and `turnur-sdk` stay green; `deploy` is skipped on the PR.
- [ ] After merge to `main`, confirm the `deploy` job assumes `TurnurGitHubActionsDeploy` and deploys `TurnurApiStack`.
- [ ] Confirm the smoke step hits `HttpApiUrl/v1/health` and gets `{ "ok": true }`.